### PR TITLE
perf(parser): zero-allocation envelope parsing via lifetime borrows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Start all dependencies (TimescaleDB + Soroban RPC)
+docker compose up -d
+
+# Run all tests (requires DATABASE_URL env var pointing at a running TimescaleDB)
+cargo test --all-features
+
+# Lint (CI enforces zero warnings)
+cargo clippy --all-targets -- -D warnings
+
+# Run a single test by name
+cargo test <test_name>
+
+# Run tests in a specific module
+cargo test --test gateway_tests
+cargo test --test tariffs_tests
+
+# Run benchmarks
+cargo bench --bench parser_bench
+```
+
+The service listens on port **8443** (`0.0.0.0:8443`). The default database URL used when `DATABASE_URL` is unset is `postgres://utility:utility_secret@localhost:5432/utility_test`.
+
+## Architecture
+
+The backend ingests telemetry from hardware utility meters, applies tariff pricing, and settles consumption on the Stellar blockchain via Soroban smart contracts.
+
+### Module map
+
+| Module | Purpose |
+|---|---|
+| `src/gateway/` | Hardware meter interface layer |
+| `src/tariffs/` | Dynamic pricing engine |
+| `src/time_series/` | TimescaleDB ingestion and anomaly detection |
+| `src/soroban/` | Stellar/Soroban blockchain settlement |
+| `src/api/` | REST API (Axum, port 8443) |
+
+### Data flow
+
+```
+Hardware meter (mTLS) → parse_envelope (gateway/parser.rs)
+  → signature verify (gateway/crypto.rs)  → BackpressureFilter (gateway/stream.rs)
+  → DiagnosticEngine (time_series/analytics.rs)
+  → TariffEngine (tariffs/engine.rs)
+  → NonceSequencer (soroban/sequencer.rs) → Soroban RPC (soroban/rpc.rs)
+```
+
+### Key design points
+
+**`gateway/crypto.rs` — MeterRegistry + BloomFilter**
+The `MeterRegistry` stores `MeterIdentity` structs (ed25519 public keys). It uses a custom `BloomFilter` as a certificate revocation list (CRL) sized for 1 M entries at 1 % FPR. TPM attestation on enrollment is optional but supported. A `lazy_static` `GLOBAL_REGISTRY` is the live singleton; mutable operations require acquiring its `Mutex`.
+
+**`gateway/parser.rs` — zero-copy envelope parsing**
+`CompressedEnvelope<'a>` borrows from the input slice — `meter_id: &'a str`, `payload: &'a [u8]`, `checksum: [u8; 32]`. `parse_envelope` makes **zero heap allocations**. Wire format: `[u16 BE meter_id_len][UTF-8 meter_id][payload][32-byte checksum]`. The Criterion benchmark in `benches/parser_bench.rs` asserts this contract with a `CountingAllocator` global allocator.
+
+**`soroban/sequencer.rs` — per-grid nonce sequencer**
+`NonceSequencer` issues monotonically increasing nonces per grid ID using atomic CAS and a block-reservation scheme (`NONCE_BLOCK_SIZE = 100`). A background reaper task evicts stale grid state after 1 hour of inactivity. `commit_nonce` guards against double-spends. `NonceSequencer` is wrapped in `Arc` and injected into Axum router state.
+
+**`time_series/analytics.rs` — streaming diagnostic engine**
+`DiagnosticEngine` maintains a per-meter sliding window (default 30 days) of `Reading`s. `analyze()` runs an STL-like decomposition (trailing moving-average trend + median monthly seasonal factors), fits a 2-covariate OLS weather model, computes a dynamic p95 anomaly threshold, and classifies probable cause (Leak / Theft / SensorFault / SeasonalVariation). A `lazy_static` `GLOBAL_ENGINE` is used by API handlers. The legacy `analyze_consumption` function (static threshold baseline) is kept for backward compatibility.
+
+**`soroban/preflight.rs` — transaction fee simulation**
+`run_preflight` calls Soroban's `simulateTransaction` RPC up to `max_iterations` times, iteratively tightening the instruction leeway. Results are cached in a `lazy_static` LRU cache keyed on `(contract_id, sha256(operation_xdr))`. `budget_optimizer` provides a binary-search helper for fee minimisation.
+
+**`time_series/pool.rs` — multi-tenant DB pools**
+`MultiTenantPoolManager` holds one `deadpool-postgres` pool per tenant. The `get_connection` method records a starvation metric on pool exhaustion. Credentials are currently hardcoded (`utility`/`utility_secret`).
+
+**`api/alloc_tracker.rs` — allocation timing middleware**
+`TrackingAllocator` wraps `System` and records allocation/deallocation latency into the `GC_PAUSE_SECONDS` Prometheus counter. It is not yet wired up as `#[global_allocator]` — that attribute lives in `benches/parser_bench.rs` for the benchmark binary only.
+
+### API routes
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/health` | Liveness probe |
+| GET | `/readyz` | Readiness probe |
+| GET | `/api/v1/meters` | List meters |
+| GET | `/api/v1/meters/:id` | Get meter |
+| POST | `/api/v1/meters/register` | Register meter with optional TPM attestation |
+| POST | `/api/v1/meters/rotate-key` | Rotate meter signing key |
+| GET | `/api/v1/tariffs` | List tariff schedules |
+| POST | `/api/v1/readings` | Submit meter reading |
+| POST | `/api/v1/settle` | Trigger blockchain settlement |
+| GET | `/api/v1/time-series/diagnostics/:meter_id` | Run diagnostic analysis |
+| POST | `/api/v1/calibrate/:meter_id` | Calibrate meter drift |
+| GET | `/api/v1/nonce/status` | Grid nonce high-water marks |
+| GET | `/metrics` | Prometheus metrics |
+
+### Fixed-point arithmetic
+
+`tariffs/math.rs` uses the `fixed` crate (`I64F64`) for commodity unit scaling to avoid floating-point rounding in settlement calculations.
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DATABASE_URL` | `postgres://utility:utility_secret@localhost:5432/utility_test` | TimescaleDB connection |
+| `SOROBAN_RPC_URL` | — | Soroban JSON-RPC endpoint |
+| `RUST_LOG` | `info` | Log filter (`tracing-subscriber`) |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,8 @@ default = []
 name = "utility_backend"
 path = "src/lib.rs"
 
+[[bench]]
+name = "parser_bench"
+harness = false
+
 

--- a/benches/parser_bench.rs
+++ b/benches/parser_bench.rs
@@ -1,0 +1,82 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use utility_backend::gateway::parser::parse_envelope;
+
+// Counting allocator — tracks heap allocations to enforce the zero-alloc contract.
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+struct CountingAllocator;
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        System.alloc(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        System.alloc_zeroed(layout)
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+fn make_envelope(meter_id: &str, payload: &[u8]) -> Vec<u8> {
+    let id = meter_id.as_bytes();
+    let mut buf = Vec::with_capacity(2 + id.len() + payload.len() + 32);
+    buf.extend_from_slice(&(id.len() as u16).to_be_bytes());
+    buf.extend_from_slice(id);
+    buf.extend_from_slice(payload);
+    buf.extend_from_slice(&[0xABu8; 32]);
+    buf
+}
+
+fn bench_zero_alloc(c: &mut Criterion) {
+    let payload = vec![0u8; 256];
+    let data = make_envelope("MTR-0001-SENSOR-A", &payload);
+
+    c.bench_function("parse_envelope/zero_alloc_contract", |b| {
+        b.iter(|| {
+            let before = ALLOC_COUNT.load(Ordering::Relaxed);
+            let result = parse_envelope(black_box(&data));
+            let after = ALLOC_COUNT.load(Ordering::Relaxed);
+            assert_eq!(
+                after - before,
+                0,
+                "parse_envelope made {} unexpected heap allocation(s)",
+                after - before
+            );
+            black_box(result.unwrap());
+        })
+    });
+}
+
+fn bench_throughput(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse_envelope/throughput");
+    for &total_size in &[64usize, 256, 512, 1024, 2048] {
+        let payload_len = total_size.saturating_sub(2 + 8 + 32); // header + "MTR-BNCH" + checksum
+        let payload = vec![0u8; payload_len];
+        let data = make_envelope("MTR-BNCH", &payload);
+
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(
+            BenchmarkId::new("envelope_bytes", total_size),
+            &data,
+            |b, d| {
+                b.iter(|| black_box(parse_envelope(black_box(d)).unwrap()));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_zero_alloc, bench_throughput);
+criterion_main!(benches);

--- a/src/gateway/parser.rs
+++ b/src/gateway/parser.rs
@@ -20,8 +20,8 @@ pub fn parse_envelope(data: &[u8]) -> Result<CompressedEnvelope<'_>, &'static st
     if data.len() < 2 + meter_id_len + 32 {
         return Err("malformed envelope: meter_id truncated");
     }
-    let meter_id = str::from_utf8(&data[2..2 + meter_id_len])
-        .map_err(|_| "invalid utf-8 meter_id")?;
+    let meter_id =
+        str::from_utf8(&data[2..2 + meter_id_len]).map_err(|_| "invalid utf-8 meter_id")?;
     let payload_start = 2 + meter_id_len;
     let payload_end = data.len() - 32;
     let payload = &data[payload_start..payload_end];

--- a/src/gateway/parser.rs
+++ b/src/gateway/parser.rs
@@ -1,10 +1,18 @@
-pub struct CompressedEnvelope {
-    pub meter_id: String,
-    pub payload: Vec<u8>,
+use std::str;
+
+/// A zero-copy view into a raw envelope buffer.
+///
+/// Lifetime `'a` is tied to the input buffer — no heap allocations are made during parsing.
+pub struct CompressedEnvelope<'a> {
+    pub meter_id: &'a str,
+    pub payload: &'a [u8],
     pub checksum: [u8; 32],
 }
 
-pub fn parse_envelope(data: &[u8]) -> Result<CompressedEnvelope, &'static str> {
+/// Parses a compressed envelope from `data` with zero heap allocations.
+///
+/// Wire format: `[u16 BE meter_id_len][meter_id UTF-8 bytes][payload bytes][32-byte checksum]`
+pub fn parse_envelope(data: &[u8]) -> Result<CompressedEnvelope<'_>, &'static str> {
     if data.len() < 40 {
         return Err("envelope too short");
     }
@@ -12,12 +20,11 @@ pub fn parse_envelope(data: &[u8]) -> Result<CompressedEnvelope, &'static str> {
     if data.len() < 2 + meter_id_len + 32 {
         return Err("malformed envelope: meter_id truncated");
     }
-    let meter_id_bytes = &data[2..2 + meter_id_len];
-    let meter_id =
-        String::from_utf8(meter_id_bytes.to_vec()).map_err(|_| "invalid utf-8 meter_id")?;
+    let meter_id = str::from_utf8(&data[2..2 + meter_id_len])
+        .map_err(|_| "invalid utf-8 meter_id")?;
     let payload_start = 2 + meter_id_len;
     let payload_end = data.len() - 32;
-    let payload = data[payload_start..payload_end].to_vec();
+    let payload = &data[payload_start..payload_end];
     let mut checksum = [0u8; 32];
     checksum.copy_from_slice(&data[payload_end..]);
     Ok(CompressedEnvelope {


### PR DESCRIPTION
## Summary

Closes #7

- **`CompressedEnvelope<'a>`** now borrows from the input buffer with lifetime `'a` — `meter_id: &'a str`, `payload: &'a [u8]` — eliminating all heap allocations during `parse_envelope`
- Replaced `String::from_utf8(meter_id_bytes.to_vec())` with `str::from_utf8(meter_id_bytes)` (zero-copy UTF-8 validation)
- Replaced `data[..].to_vec()` for the payload slice with a direct borrow
- `checksum: [u8; 32]` remains a stack copy (unchanged, already correct)

## Benchmark

Added `benches/parser_bench.rs` (Criterion) with a `CountingAllocator` wired as `#[global_allocator]` that **asserts zero heap allocations per parse at benchmark time**. Two benchmark groups:
- `parse_envelope/zero_alloc_contract` — validates the allocation-free contract
- `parse_envelope/throughput` — measures parse latency across 64–2048 byte envelopes

## Test plan

- [ ] `cargo test --all-features` — all existing unit tests pass without modification (no callers of `parse_envelope` or `CompressedEnvelope` existed outside `parser.rs`)
- [ ] `cargo bench --bench parser_bench` — confirm `CountingAllocator` assertion passes and p50 < 200 ns
- [ ] `cargo clippy --all-targets -- -D warnings` — clean