### PR TITLE
Telemetry stream ingestion

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -3,14 +3,15 @@ use ed25519_dalek::VerifyingKey;
 use hex;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use sqlx::{Pool, Postgres};
 
 use crate::soroban::sequencer::NonceSequencer;
-
 use crate::api::metrics;
 use crate::gateway::crypto::global_registry;
 use crate::time_series::analytics::{global_engine, DiagnosticReport};
 use crate::time_series::compression::CompressionStatus;
 use crate::time_series::drift::CalibrationResult;
+use crate::time_series::ingestion::ingest_telemetry;
 
 #[derive(Serialize)]
 pub struct MeterInfo {
@@ -81,8 +82,21 @@ pub async fn list_tariffs() -> Json<Vec<&'static str>> {
     ])
 }
 
-pub async fn submit_reading(Json(_body): Json<ReadingSubmission>) -> Json<&'static str> {
-    Json("reading accepted")
+pub async fn submit_reading(
+    State(pool): State<Pool<Postgres>>,
+    Json(body): Json<ReadingSubmission>,
+) -> Result<Json<&'static str>, StatusCode> {
+    let recorded_at = chrono::DateTime::parse_from_rfc3339(&body.timestamp)
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .unwrap_or_else(|_| chrono::Utc::now());
+
+    match ingest_telemetry(&pool, &body.meter_id, body.value, recorded_at).await {
+        Ok(_) => Ok(Json("reading accepted")),
+        Err(e) => {
+            tracing::error!(error = %e, "failed to ingest reading");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
 }
 
 pub async fn settle_account(Json(_body): Json<SettlementRequest>) -> Json<&'static str> {

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -2,12 +2,12 @@ use axum::{extract::Path, extract::State, http::StatusCode, response::IntoRespon
 use ed25519_dalek::VerifyingKey;
 use hex;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 use sqlx::{Pool, Postgres};
+use std::sync::Arc;
 
-use crate::soroban::sequencer::NonceSequencer;
 use crate::api::metrics;
 use crate::gateway::crypto::global_registry;
+use crate::soroban::sequencer::NonceSequencer;
 use crate::time_series::analytics::{global_engine, DiagnosticReport};
 use crate::time_series::compression::CompressionStatus;
 use crate::time_series::drift::CalibrationResult;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,28 @@
+use std::sync::Arc;
+use sqlx::{Pool, Postgres};
+use axum::extract::FromRef;
+use crate::soroban::sequencer::NonceSequencer;
+
 pub mod alloc_tracker;
 pub mod handlers;
 pub mod metrics;
 pub mod middleware;
 pub mod router;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub sequencer: Arc<NonceSequencer>,
+    pub db_pool: Pool<Postgres>,
+}
+
+impl FromRef<AppState> for Arc<NonceSequencer> {
+    fn from_ref(state: &AppState) -> Self {
+        state.sequencer.clone()
+    }
+}
+
+impl FromRef<AppState> for Pool<Postgres> {
+    fn from_ref(state: &AppState) -> Self {
+        state.db_pool.clone()
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
-use sqlx::{Pool, Postgres};
-use axum::extract::FromRef;
 use crate::soroban::sequencer::NonceSequencer;
+use axum::extract::FromRef;
+use sqlx::{Pool, Postgres};
+use std::sync::Arc;
 
 pub mod alloc_tracker;
 pub mod handlers;

--- a/src/api/router.rs
+++ b/src/api/router.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use axum::{
     middleware as axum_mw,
     routing::{get, post},
@@ -8,9 +6,9 @@ use axum::{
 use tower_http::cors::CorsLayer;
 
 use super::handlers;
-use crate::soroban::sequencer::NonceSequencer;
+use crate::api::AppState;
 
-pub async fn build_router(sequencer: Arc<NonceSequencer>) -> anyhow::Result<Router> {
+pub async fn build_router(state: AppState) -> anyhow::Result<Router> {
     let cors = CorsLayer::permissive();
 
     let app = Router::new()
@@ -33,14 +31,13 @@ pub async fn build_router(sequencer: Arc<NonceSequencer>) -> anyhow::Result<Rout
         .route("/api/v1/meters/rotate-key", post(handlers::rotate_key))
         .route("/api/v1/nonce/status", get(handlers::nonce_status))
         .route("/metrics", get(handlers::metrics_handler))
-        .route("/api/v1/nonce/status", get(handlers::nonce_status))
         .route(
             "/api/v1/database/compression/status",
             get(handlers::compression_status),
         )
         .layer(axum_mw::from_fn(crate::api::middleware::rate_limit_layer))
         .layer(cors)
-        .with_state(sequencer);
+        .with_state(state);
 
     Ok(app)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
+use utility_backend::api::AppState;
 use utility_backend::soroban::sequencer::NonceSequencer;
 use utility_backend::time_series::compression::{
     init_global_compression_manager, spawn_compression_monitor, CompressionPolicy,
@@ -17,19 +18,24 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("starting utility-backend service");
 
+    let db_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://utility:utility_secret@localhost:5432/utility_test".into());
+
+    let db_pool = sqlx::PgPool::connect(&db_url).await?;
+
     let sequencer = Arc::new(NonceSequencer::new());
     let reaper = sequencer.clone();
     tokio::spawn(async move {
         reaper.start_reaper().await;
     });
-    tokio::spawn(async {
-        db_active_connection_poller().await;
+
+    let metrics_pool = db_pool.clone();
+    tokio::spawn(async move {
+        db_active_connection_poller(metrics_pool).await;
     });
 
     // Initialise the global compression policy manager and spawn its
     // background monitoring task.
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://utility:utility_secret@localhost:5432/utility_test".into());
     let compression_manager = Arc::new(CompressionPolicyManager::new(
         db_url,
         CompressionPolicy::default(),
@@ -37,7 +43,12 @@ async fn main() -> anyhow::Result<()> {
     init_global_compression_manager(compression_manager.clone());
     spawn_compression_monitor(compression_manager, Duration::from_secs(60));
 
-    let app = utility_backend::api::router::build_router(sequencer).await?;
+    let state = AppState {
+        sequencer,
+        db_pool,
+    };
+
+    let app = utility_backend::api::router::build_router(state).await?;
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 8443));
     tracing::info!("listening on {}", addr);
@@ -51,16 +62,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn db_active_connection_poller() {
-    let database_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://utility:utility_secret@localhost:5432/utility_test".into());
-    let pool = match sqlx::PgPool::connect(&database_url).await {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::warn!("cannot connect to database for metrics polling: {}", e);
-            return;
-        }
-    };
+async fn db_active_connection_poller(pool: sqlx::PgPool) {
     let mut interval = tokio::time::interval(Duration::from_secs(30));
     loop {
         interval.tick().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,10 +43,7 @@ async fn main() -> anyhow::Result<()> {
     init_global_compression_manager(compression_manager.clone());
     spawn_compression_monitor(compression_manager, Duration::from_secs(60));
 
-    let state = AppState {
-        sequencer,
-        db_pool,
-    };
+    let state = AppState { sequencer, db_pool };
 
     let app = utility_backend::api::router::build_router(state).await?;
 

--- a/src/time_series/compress.sql
+++ b/src/time_series/compress.sql
@@ -54,3 +54,26 @@ $$;
 -- Composite index for efficient per-meter time-range queries
 CREATE INDEX IF NOT EXISTS idx_meter_readings_meter_id_ts
     ON meter_readings (meter_id, recorded_at DESC);
+
+-- Telemetry events table with per-meter monotonic sequencing
+CREATE TABLE IF NOT EXISTS telemetry_events (
+    meter_id TEXT NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    reading DOUBLE PRECISION NOT NULL,
+    sequence INTEGER NOT NULL,
+    UNIQUE(meter_id, sequence)
+);
+
+-- Index for efficient sequence-based retrieval by the tariff engine
+CREATE INDEX IF NOT EXISTS idx_telemetry_events_meter_id_sequence
+    ON telemetry_events (meter_id, sequence ASC);
+
+-- Hypertable setup for telemetry_events (if TimescaleDB is present)
+DO $$
+BEGIN
+    PERFORM * FROM pg_extension WHERE extname = 'timescaledb';
+    IF FOUND THEN
+        PERFORM create_hypertable('telemetry_events', 'recorded_at', if_not_exists => TRUE);
+    END IF;
+END
+$$;

--- a/src/time_series/ingestion.rs
+++ b/src/time_series/ingestion.rs
@@ -1,0 +1,63 @@
+use sqlx::{Pool, Postgres};
+use chrono::{DateTime, Utc};
+use tracing::info;
+use sha2::{Sha256, Digest};
+
+/// Ingests a telemetry reading into the database, ensuring strictly monotonic
+/// sequences per meter even under high concurrency.
+///
+/// This implementation uses a PostgreSQL advisory transaction-level lock to
+/// serialize sequence generation for a specific meter_id.
+pub async fn ingest_telemetry(
+    pool: &Pool<Postgres>,
+    meter_id: &str,
+    reading: f64,
+    recorded_at: DateTime<Utc>,
+) -> anyhow::Result<i32> {
+    let mut tx = pool.begin().await?;
+
+    // 1. Acquire advisory lock for the meter_id to serialize sequence generation.
+    // We use a stable hash (Sha256) of the meter_id to get a 64-bit integer
+    // for pg_advisory_xact_lock to ensure stability across builds and instances.
+    let mut hasher = Sha256::new();
+    hasher.update(meter_id.as_bytes());
+    let result = hasher.finalize();
+    let lock_id = i64::from_be_bytes(result[0..8].try_into().unwrap());
+
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(lock_id)
+        .execute(&mut *tx)
+        .await?;
+
+    // 2. Compute the next sequence number by finding the current max.
+    // Because we hold the advisory lock, no other transaction can be
+    // computing the next sequence for this meter_id simultaneously.
+    let next_seq: i32 = sqlx::query_scalar(
+        "SELECT COALESCE(MAX(sequence), 0) + 1 FROM telemetry_events WHERE meter_id = $1"
+    )
+    .bind(meter_id)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    // 3. Insert the new telemetry event with the computed sequence.
+    sqlx::query(
+        "INSERT INTO telemetry_events (meter_id, recorded_at, reading, sequence) VALUES ($1, $2, $3, $4)"
+    )
+    .bind(meter_id)
+    .bind(recorded_at)
+    .bind(reading)
+    .bind(next_seq)
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+
+    info!(
+        meter_id = %meter_id,
+        sequence = next_seq,
+        reading = reading,
+        "telemetry ingested successfully"
+    );
+
+    Ok(next_seq)
+}

--- a/src/time_series/ingestion.rs
+++ b/src/time_series/ingestion.rs
@@ -1,7 +1,7 @@
-use sqlx::{Pool, Postgres};
 use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use sqlx::{Pool, Postgres};
 use tracing::info;
-use sha2::{Sha256, Digest};
 
 /// Ingests a telemetry reading into the database, ensuring strictly monotonic
 /// sequences per meter even under high concurrency.
@@ -33,7 +33,7 @@ pub async fn ingest_telemetry(
     // Because we hold the advisory lock, no other transaction can be
     // computing the next sequence for this meter_id simultaneously.
     let next_seq: i32 = sqlx::query_scalar(
-        "SELECT COALESCE(MAX(sequence), 0) + 1 FROM telemetry_events WHERE meter_id = $1"
+        "SELECT COALESCE(MAX(sequence), 0) + 1 FROM telemetry_events WHERE meter_id = $1",
     )
     .bind(meter_id)
     .fetch_one(&mut *tx)

--- a/src/time_series/mod.rs
+++ b/src/time_series/mod.rs
@@ -1,4 +1,5 @@
 pub mod analytics;
 pub mod compression;
 pub mod drift;
+pub mod ingestion;
 pub mod pool;

--- a/tests/time_series_tests.rs
+++ b/tests/time_series_tests.rs
@@ -159,3 +159,60 @@ fn test_global_engine_is_accessible() {
     let report = guard.get_diagnostics("GLOBAL");
     assert!(report.is_some());
 }
+
+#[tokio::test]
+#[ignore] // Requires a running PostgreSQL/TimescaleDB instance
+async fn test_concurrent_telemetry_ingestion_ordering() {
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://utility:utility_secret@localhost:5432/utility_test".into());
+    let pool = sqlx::PgPool::connect(&database_url).await.unwrap();
+
+    // Clean up before test
+    sqlx::query("DELETE FROM telemetry_events WHERE meter_id = 'CONCURRENT-MTR'")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let meter_id = "CONCURRENT-MTR";
+    let num_concurrent = 10;
+    let mut handles = vec![];
+
+    for i in 0..num_concurrent {
+        let p = pool.clone();
+        let mid = meter_id.to_string();
+        handles.push(tokio::spawn(async move {
+            utility_backend::time_series::ingestion::ingest_telemetry(
+                &p,
+                &mid,
+                100.0 + (i as f64),
+                chrono::Utc::now(),
+            )
+            .await
+        }));
+    }
+
+    let mut sequences = vec![];
+    for h in handles {
+        let seq = h.await.unwrap().unwrap();
+        sequences.push(seq);
+    }
+
+    sequences.sort();
+
+    // Verify that we have unique, dense sequences from 1 to 10
+    assert_eq!(sequences.len(), num_concurrent);
+    for (i, &seq) in sequences.iter().enumerate() {
+        assert_eq!(seq, (i + 1) as i32, "Sequence mismatch at index {}", i);
+    }
+
+    // Double check the database content
+    let db_sequences: Vec<i32> = sqlx::query_scalar(
+        "SELECT sequence FROM telemetry_events WHERE meter_id = $1 ORDER BY sequence ASC"
+    )
+    .bind(meter_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(db_sequences, sequences);
+}

--- a/tests/time_series_tests.rs
+++ b/tests/time_series_tests.rs
@@ -207,7 +207,7 @@ async fn test_concurrent_telemetry_ingestion_ordering() {
 
     // Double check the database content
     let db_sequences: Vec<i32> = sqlx::query_scalar(
-        "SELECT sequence FROM telemetry_events WHERE meter_id = $1 ORDER BY sequence ASC"
+        "SELECT sequence FROM telemetry_events WHERE meter_id = $1 ORDER BY sequence ASC",
     )
     .bind(meter_id)
     .fetch_all(&pool)


### PR DESCRIPTION
This PR addresses the race condition in telemetry ingestion where concurrent reads from the same meter could result in duplicate sequence numbers.

Key changes:
- Created `telemetry_events` table in `src/time_series/compress.sql` with a `UNIQUE(meter_id, sequence)` constraint.
- Implemented `ingest_telemetry` in `src/time_series/ingestion.rs` using transaction-level advisory locks (`pg_advisory_xact_lock`) with stable SHA-256 hashing of `meter_id`.
- Refactored `AppState` in `src/api/mod.rs` and updated `src/api/handlers.rs` to use `sqlx::PgPool` via `axum::extract::FromRef`.
- Preserved existing security middleware (Rate Limiter and CORS) and API contracts.
- Added a concurrent ingestion test in `tests/time_series_tests.rs` (marked `#[ignore]` as it requires a live DB).
- Verified that all existing tests pass.

---

Closes #35 