### PR TITLE
Resource tokenization deposit attestation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,14 +63,10 @@ path = "src/lib.rs"
 name = "parser_bench"
 harness = false
 
-<<<<<<< Resource-Tokenization-Deposit-Attestation
 [[test]]
 name = "double_mint_prevention"
 path = "tests/integration/double_mint_prevention.rs"
-=======
+
 [[bench]]
 name = "merkle_bench"
 harness = false
-
-
->>>>>>> main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,4 +63,6 @@ path = "src/lib.rs"
 name = "parser_bench"
 harness = false
 
-
+[[test]]
+name = "double_mint_prevention"
+path = "tests/integration/double_mint_prevention.rs"

--- a/db/processed_deposits.sql
+++ b/db/processed_deposits.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS processed_deposits (
+    id BIGSERIAL PRIMARY KEY,
+    deposit_id TEXT NOT NULL,
+    idempotency_key UUID NOT NULL,
+    processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT processed_deposits_deposit_id_key UNIQUE (deposit_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS processed_deposits_idempotency_key_idx
+    ON processed_deposits (idempotency_key);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod gateway;
+pub mod settlement;
 pub mod soroban;
 pub mod tariffs;
 pub mod time_series;

--- a/src/settlement/attestation_verifier.rs
+++ b/src/settlement/attestation_verifier.rs
@@ -1,0 +1,126 @@
+use async_trait::async_trait;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use thiserror::Error;
+use uuid::Uuid;
+
+use super::queue::{DedupClaim, DepositDedupStore};
+use super::submitter::{MintSubmitter, MintTransaction};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DepositAttestation {
+    pub deposit_id: String,
+    pub resource_id: String,
+    pub amount: u64,
+    pub meter_id: String,
+    pub signature: [u8; 64],
+}
+
+impl DepositAttestation {
+    pub fn signing_payload(&self) -> Vec<u8> {
+        format!(
+            "{}:{}:{}:{}",
+            self.deposit_id, self.resource_id, self.amount, self.meter_id
+        )
+        .into_bytes()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationOutcome {
+    Submitted {
+        deposit_id: String,
+        transaction_id: String,
+    },
+    DuplicateSkipped {
+        deposit_id: String,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum AttestationError {
+    #[error("invalid attestation signature")]
+    InvalidSignature,
+    #[error("dedup store error: {0}")]
+    DedupStore(String),
+    #[error("mint submission error: {0}")]
+    Submit(String),
+}
+
+#[async_trait]
+pub trait AttestationQueue: Send + Sync {
+    async fn next_attestation(&self) -> Result<Option<DepositAttestation>, AttestationError>;
+}
+
+pub struct AttestationVerifier<Q, D, S> {
+    queue: Q,
+    dedup_store: D,
+    submitter: S,
+    verifying_key: VerifyingKey,
+}
+
+impl<Q, D, S> AttestationVerifier<Q, D, S>
+where
+    Q: AttestationQueue,
+    D: DepositDedupStore,
+    S: MintSubmitter,
+{
+    pub fn new(queue: Q, dedup_store: D, submitter: S, verifying_key: VerifyingKey) -> Self {
+        Self {
+            queue,
+            dedup_store,
+            submitter,
+            verifying_key,
+        }
+    }
+
+    pub async fn verify_and_submit(&self) -> Result<Option<VerificationOutcome>, AttestationError> {
+        let Some(attestation) = self.queue.next_attestation().await? else {
+            return Ok(None);
+        };
+
+        self.verify_signature(&attestation)?;
+
+        let idempotency_key = idempotency_key_for_deposit(&attestation.deposit_id);
+        let claim = self
+            .dedup_store
+            .claim_deposit(&attestation.deposit_id, idempotency_key)
+            .await
+            .map_err(AttestationError::DedupStore)?;
+
+        match claim {
+            DedupClaim::AlreadyClaimed => Ok(Some(VerificationOutcome::DuplicateSkipped {
+                deposit_id: attestation.deposit_id,
+            })),
+            DedupClaim::Claimed { idempotency_key } => {
+                let tx = MintTransaction::from_attestation(&attestation, idempotency_key);
+                let transaction_id = self
+                    .submitter
+                    .submit_mint_transaction(tx)
+                    .await
+                    .map_err(AttestationError::Submit)?;
+                Ok(Some(VerificationOutcome::Submitted {
+                    deposit_id: attestation.deposit_id,
+                    transaction_id,
+                }))
+            }
+        }
+    }
+
+    fn verify_signature(&self, attestation: &DepositAttestation) -> Result<(), AttestationError> {
+        let signature = Signature::from_bytes(&attestation.signature);
+        self.verifying_key
+            .verify(&attestation.signing_payload(), &signature)
+            .map_err(|_| AttestationError::InvalidSignature)
+    }
+}
+
+pub fn idempotency_key_for_deposit(deposit_id: &str) -> Uuid {
+    use sha2::{Digest, Sha256};
+
+    let digest = Sha256::digest(format!("utility-backend:deposit:{deposit_id}").as_bytes());
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    bytes[6] = (bytes[6] & 0x0f) | 0x80;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    Uuid::from_bytes(bytes)
+}

--- a/src/settlement/mod.rs
+++ b/src/settlement/mod.rs
@@ -1,7 +1,4 @@
-<<<<<<< Resource-Tokenization-Deposit-Attestation
 pub mod attestation_verifier;
+pub mod merkle;
 pub mod queue;
 pub mod submitter;
-=======
-pub mod merkle;
->>>>>>> main

--- a/src/settlement/mod.rs
+++ b/src/settlement/mod.rs
@@ -1,0 +1,3 @@
+pub mod attestation_verifier;
+pub mod queue;
+pub mod submitter;

--- a/src/settlement/queue.rs
+++ b/src/settlement/queue.rs
@@ -1,0 +1,73 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DedupClaim {
+    Claimed { idempotency_key: Uuid },
+    AlreadyClaimed,
+}
+
+#[async_trait]
+pub trait DepositDedupStore: Send + Sync {
+    async fn claim_deposit(
+        &self,
+        deposit_id: &str,
+        idempotency_key: Uuid,
+    ) -> Result<DedupClaim, String>;
+}
+
+#[derive(Clone)]
+pub struct PgDepositDedupStore {
+    pool: PgPool,
+}
+
+impl PgDepositDedupStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl DepositDedupStore for PgDepositDedupStore {
+    async fn claim_deposit(
+        &self,
+        deposit_id: &str,
+        idempotency_key: Uuid,
+    ) -> Result<DedupClaim, String> {
+        let mut tx = self.pool.begin().await.map_err(|err| err.to_string())?;
+        let lock_key = advisory_lock_key(deposit_id);
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(lock_key)
+            .execute(&mut *tx)
+            .await
+            .map_err(|err| err.to_string())?;
+
+        let inserted = sqlx::query(
+            "INSERT INTO processed_deposits (deposit_id, idempotency_key) VALUES ($1, $2) \
+             ON CONFLICT (deposit_id) DO NOTHING RETURNING id",
+        )
+        .bind(deposit_id)
+        .bind(idempotency_key)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|err| err.to_string())?;
+
+        tx.commit().await.map_err(|err| err.to_string())?;
+        if inserted.is_some() {
+            Ok(DedupClaim::Claimed { idempotency_key })
+        } else {
+            Ok(DedupClaim::AlreadyClaimed)
+        }
+    }
+}
+
+fn advisory_lock_key(deposit_id: &str) -> i64 {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(format!("deposit:{deposit_id}").as_bytes());
+    i64::from_be_bytes(
+        digest[..8]
+            .try_into()
+            .expect("sha digest has at least 8 bytes"),
+    )
+}

--- a/src/settlement/submitter.rs
+++ b/src/settlement/submitter.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use super::attestation_verifier::DepositAttestation;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MintTransaction {
+    pub deposit_id: String,
+    pub resource_id: String,
+    pub amount: u64,
+    pub idempotency_key: Uuid,
+    pub memo: String,
+}
+
+impl MintTransaction {
+    pub fn from_attestation(attestation: &DepositAttestation, idempotency_key: Uuid) -> Self {
+        Self {
+            deposit_id: attestation.deposit_id.clone(),
+            resource_id: attestation.resource_id.clone(),
+            amount: attestation.amount,
+            idempotency_key,
+            memo: format!(
+                "deposit:{};idempotency:{}",
+                attestation.deposit_id, idempotency_key
+            ),
+        }
+    }
+}
+
+#[async_trait]
+pub trait MintSubmitter: Send + Sync {
+    async fn submit_mint_transaction(&self, transaction: MintTransaction)
+        -> Result<String, String>;
+}

--- a/tests/integration/double_mint_prevention.rs
+++ b/tests/integration/double_mint_prevention.rs
@@ -1,0 +1,131 @@
+use std::collections::{HashSet, VecDeque};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ed25519_dalek::{Signer, SigningKey};
+use parking_lot::Mutex;
+use rand::rngs::OsRng;
+use tokio::task::JoinSet;
+use utility_backend::settlement::attestation_verifier::{
+    AttestationError, AttestationQueue, AttestationVerifier, DepositAttestation,
+    VerificationOutcome,
+};
+use utility_backend::settlement::queue::{DedupClaim, DepositDedupStore};
+use utility_backend::settlement::submitter::{MintSubmitter, MintTransaction};
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct InMemoryQueue {
+    attestations: Arc<Mutex<VecDeque<DepositAttestation>>>,
+}
+
+#[async_trait]
+impl AttestationQueue for InMemoryQueue {
+    async fn next_attestation(&self) -> Result<Option<DepositAttestation>, AttestationError> {
+        Ok(self.attestations.lock().pop_front())
+    }
+}
+
+#[derive(Clone, Default)]
+struct InMemoryDedupStore {
+    processed: Arc<Mutex<HashSet<String>>>,
+}
+
+#[async_trait]
+impl DepositDedupStore for InMemoryDedupStore {
+    async fn claim_deposit(
+        &self,
+        deposit_id: &str,
+        idempotency_key: Uuid,
+    ) -> Result<DedupClaim, String> {
+        let mut processed = self.processed.lock();
+        if processed.insert(deposit_id.to_string()) {
+            Ok(DedupClaim::Claimed { idempotency_key })
+        } else {
+            Ok(DedupClaim::AlreadyClaimed)
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct RecordingSubmitter {
+    submitted: Arc<Mutex<Vec<MintTransaction>>>,
+}
+
+#[async_trait]
+impl MintSubmitter for RecordingSubmitter {
+    async fn submit_mint_transaction(
+        &self,
+        transaction: MintTransaction,
+    ) -> Result<String, String> {
+        tokio::task::yield_now().await;
+        let mut submitted = self.submitted.lock();
+        submitted.push(transaction);
+        Ok(format!("tx-{}", submitted.len()))
+    }
+}
+
+fn signed_attestation(
+    signing_key: &SigningKey,
+    deposit_id: &str,
+    meter_id: &str,
+) -> DepositAttestation {
+    let mut attestation = DepositAttestation {
+        deposit_id: deposit_id.to_string(),
+        resource_id: "resource-node-7".to_string(),
+        amount: 42,
+        meter_id: meter_id.to_string(),
+        signature: [0; 64],
+    };
+    attestation.signature = signing_key.sign(&attestation.signing_payload()).to_bytes();
+    attestation
+}
+
+#[tokio::test]
+async fn duplicate_deposit_attestations_submit_exactly_one_mint() {
+    let signing_key = SigningKey::generate(&mut OsRng);
+    let verifying_key = signing_key.verifying_key();
+    let attestations = (0..10)
+        .map(|idx| {
+            signed_attestation(
+                &signing_key,
+                "deposit-duplicate-001",
+                &format!("meter-{idx}"),
+            )
+        })
+        .collect::<VecDeque<_>>();
+
+    let queue = InMemoryQueue {
+        attestations: Arc::new(Mutex::new(attestations)),
+    };
+    let dedup = InMemoryDedupStore::default();
+    let submitter = RecordingSubmitter::default();
+
+    let mut tasks = JoinSet::new();
+    for _ in 0..10 {
+        let verifier = AttestationVerifier::new(
+            queue.clone(),
+            dedup.clone(),
+            submitter.clone(),
+            verifying_key,
+        );
+        tasks.spawn(async move { verifier.verify_and_submit().await });
+    }
+
+    let mut submitted = 0;
+    let mut skipped = 0;
+    while let Some(result) = tasks.join_next().await {
+        match result.expect("task panicked").expect("verification failed") {
+            Some(VerificationOutcome::Submitted { .. }) => submitted += 1,
+            Some(VerificationOutcome::DuplicateSkipped { .. }) => skipped += 1,
+            None => {}
+        }
+    }
+
+    assert_eq!(submitted, 1);
+    assert_eq!(skipped, 9);
+    let txs = submitter.submitted.lock();
+    assert_eq!(txs.len(), 1);
+    assert_eq!(txs[0].deposit_id, "deposit-duplicate-001");
+    assert!(txs[0].memo.contains("idempotency:"));
+}


### PR DESCRIPTION
### Motivation
- Prevent a race where concurrent off-chain deposit attestations for the same `deposit_id` can cause duplicate minting on the Soroban contract. 
- Ensure the deduplication step is atomic and that submitted mint transactions carry a stable idempotency key to allow idempotent processing by downstream systems.

### Description
- Exported a new `settlement` module and added an attestation verification pipeline in `src/settlement/attestation_verifier.rs` that verifies Ed25519 signatures with `ed25519-dalek`, computes a per-deposit idempotency UUID, and coordinates claiming + submission via the dedup store and submitter interfaces. 
- Implemented a PostgreSQL-backed dedup store in `src/settlement/queue.rs` that acquires a transaction-scoped advisory lock (`pg_advisory_xact_lock`) and performs `INSERT ... ON CONFLICT (deposit_id) DO NOTHING RETURNING id` to atomically claim the first processor and skip duplicates. 
- Introduced `MintTransaction` and the `MintSubmitter` trait in `src/settlement/submitter.rs` and include the deposit-scoped idempotency key in the transaction memo so submitters can propagate idempotency to Soroban. 
- Added a DB schema file `db/processed_deposits.sql` that creates the `processed_deposits` table with a unique constraint on `deposit_id` and an index on `idempotency_key`. 
- Added an integration test `tests/integration/double_mint_prevention.rs` which spawns 10 concurrent duplicate attestations and asserts exactly one mint is submitted and nine are skipped, and registered it in `Cargo.toml`.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo test --test double_mint_prevention` and the integration test passed (1 passed; 0 failed). 
- Ran full `cargo test` and the test suite completed successfully (all tests passed).

------

Closes #32 