### PR TITLE
Merkleized batch settlement proof

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,4 +63,8 @@ path = "src/lib.rs"
 name = "parser_bench"
 harness = false
 
+[[bench]]
+name = "merkle_bench"
+harness = false
+
 

--- a/benches/merkle_bench.rs
+++ b/benches/merkle_bench.rs
@@ -1,0 +1,32 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use utility_backend::settlement::merkle::{Leaf, MerkleTree};
+
+fn leaves(n: usize) -> Vec<Leaf> {
+    (0..n)
+        .map(|i| Leaf {
+            meter_id: i as u64,
+            timestamp_ms: 1_700_000_000_000 + i as i64,
+            commodity_type: (i % 4) as u8,
+            scaled_reading: i as i128 * 1_000,
+            nonce: i as u64 ^ 0xa5a5_a5a5,
+        })
+        .collect()
+}
+
+fn merkle_bench(c: &mut Criterion) {
+    for n in [256usize, 1024, 4096, 16_384] {
+        c.bench_function(&format!("merkle_tree_build_{n}"), |b| {
+            let leaves = leaves(n);
+            b.iter(|| MerkleTree::new(black_box(&leaves)).expect("tree builds"));
+        });
+
+        c.bench_function(&format!("merkle_proof_{n}"), |b| {
+            let leaves = leaves(n);
+            let tree = MerkleTree::new(&leaves).expect("tree builds");
+            b.iter(|| tree.prove(black_box(n / 2)).expect("proof exists"));
+        });
+    }
+}
+
+criterion_group!(benches, merkle_bench);
+criterion_main!(benches);

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -77,3 +77,42 @@ pub fn set_db_waiting_requests(count: f64) {
 pub fn get_starvation_count() -> f64 {
     DB_POOL_STARVATION.get()
 }
+
+lazy_static! {
+    pub static ref MERKLE_TREE_BUILD_DURATION_MS: HistogramVec = register_histogram_vec!(
+        "utility_merkle_tree_build_duration_ms",
+        "Merkle tree construction duration in milliseconds",
+        &["commodity_type"]
+    )
+    .unwrap();
+    pub static ref BATCH_PROOF_SUBMISSION_COUNT: CounterVec = register_counter_vec!(
+        "utility_batch_proof_submission_count_total",
+        "Total number of Merkle batch proof submissions",
+        &["commodity_type", "status"]
+    )
+    .unwrap();
+    pub static ref ONCHAIN_VERIFICATION_GAS_USED: HistogramVec = register_histogram_vec!(
+        "utility_onchain_verification_gas_used",
+        "Soroban on-chain Merkle batch verification gas used",
+        &["commodity_type"]
+    )
+    .unwrap();
+}
+
+pub fn record_merkle_tree_build_duration_ms(commodity_type: &str, duration_ms: f64) {
+    MERKLE_TREE_BUILD_DURATION_MS
+        .with_label_values(&[commodity_type])
+        .observe(duration_ms);
+}
+
+pub fn record_batch_proof_submission(commodity_type: &str, status: &str) {
+    BATCH_PROOF_SUBMISSION_COUNT
+        .with_label_values(&[commodity_type, status])
+        .inc();
+}
+
+pub fn record_onchain_verification_gas_used(commodity_type: &str, gas_used: f64) {
+    ONCHAIN_VERIFICATION_GAS_USED
+        .with_label_values(&[commodity_type])
+        .observe(gas_used);
+}

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -1,0 +1,1 @@
+pub mod soroban;

--- a/src/blockchain/soroban/client.rs
+++ b/src/blockchain/soroban/client.rs
@@ -1,0 +1,37 @@
+use crate::soroban::rpc::{CircuitBreaker, SorobanRpcResponse};
+use serde_json::json;
+
+pub struct SorobanClient {
+    rpc_url: String,
+    circuit_breaker: CircuitBreaker,
+}
+
+impl SorobanClient {
+    pub fn new(rpc_url: impl Into<String>) -> Self {
+        Self {
+            rpc_url: rpc_url.into(),
+            circuit_breaker: CircuitBreaker::new(5),
+        }
+    }
+
+    pub async fn submit_batch_proof(
+        &mut self,
+        root: [u8; 32],
+        leaf_count: u32,
+        proof_hashes: Vec<[u8; 32]>,
+    ) -> Result<SorobanRpcResponse, &'static str> {
+        let payload = json!({
+            "jsonrpc": "2.0",
+            "id": "submit_batch_proof",
+            "method": "sendTransaction",
+            "params": {
+                "operation": "submit_batch_proof",
+                "root": hex::encode(root),
+                "leaf_count": leaf_count,
+                "proof_hashes": proof_hashes.into_iter().map(hex::encode).collect::<Vec<_>>()
+            }
+        });
+
+        self.circuit_breaker.call_rpc(&self.rpc_url, payload).await
+    }
+}

--- a/src/blockchain/soroban/contracts/settlement.wat
+++ b/src/blockchain/soroban/contracts/settlement.wat
@@ -1,0 +1,11 @@
+(module
+  ;; Contract sketch for the Soroban host wrapper: verify_batch(root, leaf, proof, index)
+  ;; recomputes a BLAKE2b-256 Merkle path by ordering each sibling according to
+  ;; the leaf index bit at the current depth, then compares the final 32-byte hash
+  ;; with the committed root stored for the batch leaf_count.
+  (memory (export "memory") 1)
+  (func (export "verify_batch") (param $root i32) (param $leaf i32) (param $proof i32) (param $proof_len i32) (param $index i32) (result i32)
+    ;; Placeholder WAT surface retained for CI builds that do not compile Soroban
+    ;; contracts. The Rust verifier in src/settlement/merkle.rs is the executable
+    ;; reference for sibling ordering and leaf serialization.
+    i32.const 1))

--- a/src/blockchain/soroban/mod.rs
+++ b/src/blockchain/soroban/mod.rs
@@ -1,0 +1,1 @@
+pub mod client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod api;
+pub mod blockchain;
 pub mod gateway;
+pub mod settlement;
 pub mod soroban;
 pub mod tariffs;
 pub mod time_series;
+pub mod types;

--- a/src/settlement/merkle.rs
+++ b/src/settlement/merkle.rs
@@ -1,0 +1,235 @@
+pub const HASH_LEN: usize = 32;
+pub const MAX_BATCH_LEAVES: usize = 16_384;
+pub const MAX_PROOF_LEAVES: usize = 1 << 20;
+
+pub type Hash = [u8; HASH_LEN];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Leaf {
+    pub meter_id: u64,
+    pub timestamp_ms: i64,
+    pub commodity_type: u8,
+    pub scaled_reading: i128,
+    pub nonce: u64,
+}
+
+impl Leaf {
+    pub fn encode_scale_like(&self) -> [u8; 41] {
+        let mut out = [0u8; 41];
+        out[0..8].copy_from_slice(&self.meter_id.to_le_bytes());
+        out[8..16].copy_from_slice(&self.timestamp_ms.to_le_bytes());
+        out[16] = self.commodity_type;
+        out[17..33].copy_from_slice(&self.scaled_reading.to_le_bytes());
+        out[33..41].copy_from_slice(&self.nonce.to_le_bytes());
+        out
+    }
+
+    pub fn hash(&self) -> Hash {
+        hash_tagged(b"ULB_LEAF_V1", &self.encode_scale_like())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SiblingSide {
+    Left,
+    Right,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofStep {
+    pub hash: Hash,
+    pub side: SiblingSide,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MerkleProof {
+    pub leaf_index: usize,
+    pub leaf_count: usize,
+    pub path: Vec<ProofStep>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MerkleTree {
+    levels: Vec<Vec<Hash>>,
+    leaf_count: usize,
+}
+
+impl MerkleTree {
+    pub fn new(leaves: &[Leaf]) -> Result<Self, &'static str> {
+        if leaves.is_empty() {
+            return Err("merkle tree requires at least one leaf");
+        }
+        if leaves.len() > MAX_BATCH_LEAVES {
+            return Err("merkle batch exceeds maximum leaf count");
+        }
+
+        let mut levels = Vec::new();
+        levels.push(leaves.iter().map(Leaf::hash).collect::<Vec<_>>());
+
+        while levels.last().expect("level exists").len() > 1 {
+            let current = levels.last().expect("level exists");
+            let mut next = Vec::with_capacity(current.len().div_ceil(2));
+            for pair in current.chunks(2) {
+                let right = if pair.len() == 2 { pair[1] } else { pair[0] };
+                next.push(hash_children(&pair[0], &right));
+            }
+            levels.push(next);
+        }
+
+        Ok(Self {
+            levels,
+            leaf_count: leaves.len(),
+        })
+    }
+
+    pub fn root(&self) -> Hash {
+        self.levels.last().expect("root level exists")[0]
+    }
+
+    pub fn leaf_count(&self) -> usize {
+        self.leaf_count
+    }
+
+    pub fn prove(&self, leaf_index: usize) -> Option<MerkleProof> {
+        if leaf_index >= self.leaf_count {
+            return None;
+        }
+
+        let mut index = leaf_index;
+        let mut path = Vec::with_capacity(self.levels.len().saturating_sub(1));
+        for level in &self.levels[..self.levels.len() - 1] {
+            let is_right = index % 2 == 1;
+            let sibling_index = if is_right { index - 1 } else { index + 1 };
+            let sibling_hash = level.get(sibling_index).copied().unwrap_or(level[index]);
+            path.push(ProofStep {
+                hash: sibling_hash,
+                side: if is_right {
+                    SiblingSide::Left
+                } else {
+                    SiblingSide::Right
+                },
+            });
+            index /= 2;
+        }
+
+        Some(MerkleProof {
+            leaf_index,
+            leaf_count: self.leaf_count,
+            path,
+        })
+    }
+
+    pub fn verify(root: Hash, leaf: &Leaf, proof: &MerkleProof) -> bool {
+        verify(root, leaf, proof)
+    }
+}
+
+pub fn verify(root: Hash, leaf: &Leaf, proof: &MerkleProof) -> bool {
+    if proof.leaf_count == 0
+        || proof.leaf_count > MAX_PROOF_LEAVES
+        || proof.leaf_index >= proof.leaf_count
+    {
+        return false;
+    }
+
+    let max_depth = usize::BITS as usize - (proof.leaf_count - 1).leading_zeros() as usize;
+    if proof.path.len() != max_depth {
+        return false;
+    }
+
+    let mut computed = leaf.hash();
+    for step in &proof.path {
+        computed = match step.side {
+            SiblingSide::Left => hash_children(&step.hash, &computed),
+            SiblingSide::Right => hash_children(&computed, &step.hash),
+        };
+    }
+    computed == root
+}
+
+pub fn hash_children(left: &Hash, right: &Hash) -> Hash {
+    let mut bytes = [0u8; 64];
+    bytes[..32].copy_from_slice(left);
+    bytes[32..].copy_from_slice(right);
+    hash_tagged(b"ULB_NODE_V1", &bytes)
+}
+
+fn hash_tagged(tag: &[u8], payload: &[u8]) -> Hash {
+    let mut input = Vec::with_capacity(tag.len() + payload.len());
+    input.extend_from_slice(tag);
+    input.extend_from_slice(payload);
+    blake2b_256(&input)
+}
+
+const BLAKE2B_IV: [u64; 8] = [
+    0x6a09e667f3bcc908,
+    0xbb67ae8584caa73b,
+    0x3c6ef372fe94f82b,
+    0xa54ff53a5f1d36f1,
+    0x510e527fade682d1,
+    0x9b05688c2b3e6c1f,
+    0x1f83d9abfb41bd6b,
+    0x5be0cd19137e2179,
+];
+const SIGMA: [[usize; 16]; 12] = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3],
+    [11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4],
+    [7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8],
+    [9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13],
+    [2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9],
+    [12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11],
+    [13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10],
+    [6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5],
+    [10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0],
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3],
+];
+
+fn blake2b_256(input: &[u8]) -> Hash {
+    debug_assert!(input.len() <= 128);
+    let mut h = BLAKE2B_IV;
+    h[0] ^= 0x0101_0020; // digest length 32, key length 0, fanout 1, depth 1
+    let mut block = [0u8; 128];
+    block[..input.len()].copy_from_slice(input);
+    let mut m = [0u64; 16];
+    for (i, chunk) in block.chunks_exact(8).enumerate() {
+        m[i] = u64::from_le_bytes(chunk.try_into().expect("8-byte chunk"));
+    }
+    let mut v = [0u64; 16];
+    v[..8].copy_from_slice(&h);
+    v[8..].copy_from_slice(&BLAKE2B_IV);
+    v[12] ^= input.len() as u64;
+    v[14] = !v[14];
+
+    macro_rules! g {
+        ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $y:expr) => {{
+            v[$a] = v[$a].wrapping_add(v[$b]).wrapping_add($x);
+            v[$d] = (v[$d] ^ v[$a]).rotate_right(32);
+            v[$c] = v[$c].wrapping_add(v[$d]);
+            v[$b] = (v[$b] ^ v[$c]).rotate_right(24);
+            v[$a] = v[$a].wrapping_add(v[$b]).wrapping_add($y);
+            v[$d] = (v[$d] ^ v[$a]).rotate_right(16);
+            v[$c] = v[$c].wrapping_add(v[$d]);
+            v[$b] = (v[$b] ^ v[$c]).rotate_right(63);
+        }};
+    }
+    for s in SIGMA {
+        g!(0, 4, 8, 12, m[s[0]], m[s[1]]);
+        g!(1, 5, 9, 13, m[s[2]], m[s[3]]);
+        g!(2, 6, 10, 14, m[s[4]], m[s[5]]);
+        g!(3, 7, 11, 15, m[s[6]], m[s[7]]);
+        g!(0, 5, 10, 15, m[s[8]], m[s[9]]);
+        g!(1, 6, 11, 12, m[s[10]], m[s[11]]);
+        g!(2, 7, 8, 13, m[s[12]], m[s[13]]);
+        g!(3, 4, 9, 14, m[s[14]], m[s[15]]);
+    }
+    for i in 0..8 {
+        h[i] ^= v[i] ^ v[i + 8];
+    }
+    let mut out = [0u8; HASH_LEN];
+    for (chunk, word) in out.chunks_exact_mut(8).zip(h) {
+        chunk.copy_from_slice(&word.to_le_bytes());
+    }
+    out
+}

--- a/src/settlement/mod.rs
+++ b/src/settlement/mod.rs
@@ -1,0 +1,1 @@
+pub mod merkle;

--- a/src/types/commodity.rs
+++ b/src/types/commodity.rs
@@ -1,0 +1,30 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum CommodityType {
+    Electricity = 0,
+    Gas = 1,
+    Water = 2,
+    Heat = 3,
+    Other = 255,
+}
+
+impl CommodityType {
+    pub fn scale_byte(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for CommodityType {
+    type Error = &'static str;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Electricity),
+            1 => Ok(Self::Gas),
+            2 => Ok(Self::Water),
+            3 => Ok(Self::Heat),
+            255 => Ok(Self::Other),
+            _ => Err("unknown commodity type"),
+        }
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod commodity;

--- a/tests/settlement_merkle_proof_test.rs
+++ b/tests/settlement_merkle_proof_test.rs
@@ -1,0 +1,69 @@
+use proptest::prelude::*;
+use utility_backend::settlement::merkle::{verify, Leaf, MerkleTree, SiblingSide};
+
+fn arb_leaf() -> impl Strategy<Value = Leaf> {
+    (
+        any::<u64>(),
+        any::<i64>(),
+        any::<u8>(),
+        any::<i128>(),
+        any::<u64>(),
+    )
+        .prop_map(
+            |(meter_id, timestamp_ms, commodity_type, scaled_reading, nonce)| Leaf {
+                meter_id,
+                timestamp_ms,
+                commodity_type,
+                scaled_reading,
+                nonce,
+            },
+        )
+}
+
+proptest! {
+    #[test]
+    fn verifies_valid_inclusion_proofs(leaves in prop::collection::vec(arb_leaf(), 1..256)) {
+        let tree = MerkleTree::new(&leaves).expect("tree builds");
+        for (i, leaf) in leaves.iter().enumerate() {
+            let proof = tree.prove(i).expect("proof exists");
+            prop_assert!(verify(tree.root(), leaf, &proof));
+        }
+    }
+
+    #[test]
+    fn rejects_wrong_leaf(mut leaves in prop::collection::vec(arb_leaf(), 2..128)) {
+        let tree = MerkleTree::new(&leaves).expect("tree builds");
+        let proof = tree.prove(0).expect("proof exists");
+        leaves[0].nonce = leaves[0].nonce.wrapping_add(1);
+        prop_assert!(!verify(tree.root(), &leaves[0], &proof));
+    }
+
+    #[test]
+    fn rejects_reordered_sibling_side(leaves in prop::collection::vec(arb_leaf(), 2..128)) {
+        let tree = MerkleTree::new(&leaves).expect("tree builds");
+        let mut proof = tree.prove(0).expect("proof exists");
+        if let Some(first) = proof.path.first_mut() {
+            first.side = match first.side {
+                SiblingSide::Left => SiblingSide::Right,
+                SiblingSide::Right => SiblingSide::Left,
+            };
+        }
+        prop_assert!(!verify(tree.root(), &leaves[0], &proof));
+    }
+}
+
+#[test]
+fn rejects_batches_over_limit() {
+    let leaves = vec![
+        Leaf {
+            meter_id: 1,
+            timestamp_ms: 1,
+            commodity_type: 0,
+            scaled_reading: 1,
+            nonce: 1,
+        };
+        16_385
+    ];
+
+    assert!(MerkleTree::new(&leaves).is_err());
+}


### PR DESCRIPTION
### Motivation
- Reduce O(n) on-chain transaction overhead by aggregating thousands of meter readings into a single Merkle root that can be verified on-chain with a compact proof path. 
- Meet on-chain and offline constraints: binary Merkle tree, 32-byte truncated hash, batch limit (16,384 leaves) and proof/verification gas/size targets.

### Description
- Add `src/settlement/merkle.rs` implementing `Leaf`, `MerkleTree`, `MerkleProof` and `verify` with SCALE-like encoding (`Leaf::encode_scale_like`) and a 32-byte BLAKE2b-256 digest via an inline `blake2b_256` implementation. 
- Add Soroban integration surface: `src/blockchain/soroban/client.rs` with `submit_batch_proof(root, leaf_count, proof_hashes)` and a WAT stub `src/blockchain/soroban/contracts/settlement.wat` for the on-chain `verify_batch` entrypoint. 
- Add `src/types/commodity.rs` commodity enum and register new Prometheus metrics in `src/api/metrics.rs` (`MERKLE_TREE_BUILD_DURATION_MS`, `BATCH_PROOF_SUBMISSION_COUNT`, `ONCHAIN_VERIFICATION_GAS_USED`). 
- Export new modules from the crate root (`src/lib.rs`), add property-based tests `tests/settlement_merkle_proof_test.rs`, and add Criterion benchmarks `benches/merkle_bench.rs` and `Cargo.toml` bench registration.

### Testing
- Ran `cargo fmt` successfully. 
- Ran `cargo test --offline` and all automated tests passed, including the new Merkle property-based tests in `tests/settlement_merkle_proof_test.rs`. 
- An initial non-offline `cargo test` attempt failed to fetch the crates.io index due to a network/proxy error, after which tests were rerun in `--offline` mode and completed successfully.

------

Closes #37 