### PR TITLE
Add sliding-window credit-flow backpressure for cross-shard Settlement.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod blockchain;
 pub mod gateway;
 pub mod settlement;
 pub mod soroban;
+pub mod storage;
 pub mod tariffs;
 pub mod time_series;
 pub mod transport;

--- a/src/settlement/credit_flow.rs
+++ b/src/settlement/credit_flow.rs
@@ -1,0 +1,189 @@
+//! Sliding-window, credit-based backpressure for cross-shard settlement.
+//!
+//! Each destination shard has a [`CreditFlowController`] holding a signed credit
+//! balance. A sender consumes one credit per in-flight message; the receiver
+//! replenishes credits via `CreditGrant` after processing a batch. This gives
+//! unbounded *logical* capacity (messages never silently drop) while bounding
+//! *physical* in-flight work, with spillover to a durable queue handled by the
+//! [`ShardRouter`](super::shard_router::ShardRouter).
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+
+/// Tunable bounds for the credit protocol (issue #54 invariants).
+#[derive(Clone, Copy, Debug)]
+pub struct CreditConfig {
+    /// Starting credit balance granted to each shard.
+    pub initial_credit_balance: i64,
+    /// Number of messages the receiver processes before emitting a grant; also
+    /// the size of each `CreditGrant`.
+    pub grant_batch: u32,
+    /// In-memory buffered messages per shard before spilling to disk.
+    pub in_memory_buffer: usize,
+    /// Maximum durable-queue depth per shard before the sender blocks upstream.
+    pub durable_queue_max: usize,
+    /// How long an unacknowledged message waits before retransmission.
+    pub ack_timeout: Duration,
+}
+
+impl Default for CreditConfig {
+    fn default() -> Self {
+        Self {
+            initial_credit_balance: 100_000,
+            grant_batch: 1_000,
+            in_memory_buffer: 200_000,
+            durable_queue_max: 10_000_000,
+            ack_timeout: Duration::from_secs(1),
+        }
+    }
+}
+
+/// Returned by [`CreditFlowController::acquire`] when no credit is available.
+/// The caller should spill to the durable queue or wait for a grant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CreditExhausted;
+
+impl std::fmt::Display for CreditExhausted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "credit balance exhausted")
+    }
+}
+
+impl std::error::Error for CreditExhausted {}
+
+/// Per-shard credit accounting plus unacknowledged-message tracking.
+pub struct CreditFlowController {
+    shard_id: u64,
+    credits: AtomicI64,
+    pending_acks: Mutex<HashMap<u64, Instant>>,
+    acked_watermark: AtomicU64,
+    notify: Notify,
+    config: CreditConfig,
+}
+
+impl CreditFlowController {
+    /// Create a controller for `shard_id` starting at the configured balance.
+    pub fn new(shard_id: u64, config: CreditConfig) -> Self {
+        Self {
+            shard_id,
+            credits: AtomicI64::new(config.initial_credit_balance),
+            pending_acks: Mutex::new(HashMap::new()),
+            acked_watermark: AtomicU64::new(0),
+            notify: Notify::new(),
+            config,
+        }
+    }
+
+    /// The shard this controller governs.
+    pub fn shard_id(&self) -> u64 {
+        self.shard_id
+    }
+
+    /// Current credit balance (may be observed transiently).
+    pub fn credit_balance(&self) -> i64 {
+        self.credits.load(Ordering::Acquire)
+    }
+
+    /// Try to reserve `count` credits without blocking. Returns `true` on
+    /// success; never drives the balance negative.
+    pub fn try_acquire(&self, count: u32) -> bool {
+        let count = count as i64;
+        let mut cur = self.credits.load(Ordering::Acquire);
+        loop {
+            if cur < count {
+                return false;
+            }
+            match self.credits.compare_exchange_weak(
+                cur,
+                cur - count,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => cur = actual,
+            }
+        }
+    }
+
+    /// Reserve `count` credits, or report exhaustion so the caller can spill or
+    /// wait. Non-blocking.
+    pub fn acquire(&self, count: u32) -> Result<(), CreditExhausted> {
+        if self.try_acquire(count) {
+            Ok(())
+        } else {
+            Err(CreditExhausted)
+        }
+    }
+
+    /// Wait until `count` credits can be reserved, parking on grant
+    /// notifications. Resolves once the credits have been reserved.
+    ///
+    /// A bounded re-poll backstops the wait: `Notify::notify_waiters` stores no
+    /// permit, so a grant racing ahead of registration could otherwise be
+    /// missed. The timeout guarantees liveness at the cost of a small worst-case
+    /// latency in that rare race.
+    pub async fn wait_for_credits(&self, count: u32) {
+        loop {
+            if self.try_acquire(count) {
+                return;
+            }
+            let notified = self.notify.notified();
+            if self.try_acquire(count) {
+                return;
+            }
+            let _ = tokio::time::timeout(Duration::from_millis(50), notified).await;
+        }
+    }
+
+    /// Add `delta` credits (on receiving a `CreditGrant`) and wake any waiters.
+    pub fn grant_credits(&self, delta: u32) {
+        self.credits.fetch_add(delta as i64, Ordering::AcqRel);
+        self.notify.notify_waiters();
+    }
+
+    /// Record that `msg_id` has been forwarded and is awaiting acknowledgement.
+    pub fn record_pending(&self, msg_id: u64) {
+        self.pending_acks.lock().insert(msg_id, Instant::now());
+    }
+
+    /// Number of messages awaiting acknowledgement.
+    pub fn pending_count(&self) -> usize {
+        self.pending_acks.lock().len()
+    }
+
+    /// Highest contiguous `msg_id` acknowledged by the receiver.
+    pub fn acked_watermark(&self) -> u64 {
+        self.acked_watermark.load(Ordering::Acquire)
+    }
+
+    /// Apply an incoming ack: advance the watermark and drop every pending entry
+    /// at or below `acked_msg_id`.
+    pub fn process_ack(&self, acked_msg_id: u64) {
+        self.acked_watermark
+            .fetch_max(acked_msg_id, Ordering::AcqRel);
+        let mut pending = self.pending_acks.lock();
+        pending.retain(|id, _| *id > acked_msg_id);
+    }
+
+    /// Ids of messages that have been pending longer than the ack timeout and
+    /// should be retransmitted. Their timers are reset so they are not returned
+    /// again until the timeout elapses afresh.
+    pub fn timed_out(&self) -> Vec<u64> {
+        let now = Instant::now();
+        let timeout = self.config.ack_timeout;
+        let mut pending = self.pending_acks.lock();
+        let stale: Vec<u64> = pending
+            .iter()
+            .filter(|(_, sent)| now.duration_since(**sent) >= timeout)
+            .map(|(id, _)| *id)
+            .collect();
+        for id in &stale {
+            pending.insert(*id, now);
+        }
+        stale
+    }
+}

--- a/src/settlement/executor.rs
+++ b/src/settlement/executor.rs
@@ -1,0 +1,64 @@
+//! Settlement execution entry point for cross-shard messaging.
+//!
+//! The executor is the integration seam described in issue #54: before emitting
+//! cross-shard settlement messages it goes through the credit-flow-controlled
+//! [`ShardRouter`], so flow control and durable spillover apply uniformly to all
+//! settlement traffic.
+
+use std::io;
+use std::sync::Arc;
+
+use super::messages::{AckMessage, CreditGrant};
+use super::shard_router::{MessageSink, ShardRouter};
+
+/// Drives credit-controlled cross-shard settlement delivery.
+pub struct SettlementExecutor {
+    router: Arc<ShardRouter>,
+}
+
+impl SettlementExecutor {
+    /// Build an executor over the given router.
+    pub fn new(router: Arc<ShardRouter>) -> Self {
+        Self { router }
+    }
+
+    /// The underlying router (for wiring inbound acks/grants and drain loops).
+    pub fn router(&self) -> &Arc<ShardRouter> {
+        &self.router
+    }
+
+    /// Submit one settlement payload to `dest_shard`. Returns the assigned
+    /// `msg_id`. Flow control / spillover is enforced inside the router.
+    pub async fn submit_cross_shard(&self, dest_shard: u64, payload: Vec<u8>) -> io::Result<u64> {
+        self.router.send(dest_shard, payload).await
+    }
+
+    /// Submit a batch of payloads to `dest_shard`, returning the assigned ids in
+    /// order. Credits are acquired per message by the router as each is enqueued.
+    pub async fn submit_batch(
+        &self,
+        dest_shard: u64,
+        payloads: Vec<Vec<u8>>,
+    ) -> io::Result<Vec<u64>> {
+        let mut ids = Vec::with_capacity(payloads.len());
+        for payload in payloads {
+            ids.push(self.router.send(dest_shard, payload).await?);
+        }
+        Ok(ids)
+    }
+
+    /// Push buffered/spilled traffic for `dest_shard` onto the wire.
+    pub async fn flush(&self, dest_shard: u64, sink: &dyn MessageSink) -> io::Result<usize> {
+        self.router.drain(dest_shard, sink).await
+    }
+
+    /// Apply an acknowledgement received from a peer.
+    pub fn on_ack(&self, ack: AckMessage) {
+        self.router.on_ack(ack);
+    }
+
+    /// Apply a credit grant received from a peer.
+    pub fn on_credit_grant(&self, grant: CreditGrant) {
+        self.router.on_credit_grant(grant);
+    }
+}

--- a/src/settlement/messages.proto
+++ b/src/settlement/messages.proto
@@ -1,0 +1,37 @@
+// Canonical schema for cross-shard settlement flow-control messages (issue #54).
+//
+// NOTE: This file documents the wire contract. The Rust implementation in
+// `messages.rs` mirrors these definitions with a hand-rolled little-endian codec
+// so the build does not require a `protoc`/`prost` toolchain. If a protobuf
+// backend is introduced, generate from this file and keep the field numbers and
+// struct layout in sync with `messages.rs`.
+
+syntax = "proto3";
+
+package utility.settlement.v1;
+
+// A single settlement payload routed from one shard to another.
+message SettlementMessage {
+  // Destination shard this message is addressed to.
+  uint64 shard_id = 1;
+  // Monotonic per-stream sequence id (basis for dedup + ack).
+  uint64 msg_id = 2;
+  // Opaque settlement payload (avg 256 B, max 4 KB).
+  bytes payload = 3;
+}
+
+// Credit replenishment sent by the receiver after processing a batch.
+message CreditGrant {
+  // Shard the grant is addressed to (the original sender).
+  uint64 shard_id = 1;
+  // Number of additional credits granted.
+  uint32 delta = 2;
+}
+
+// Acknowledgement carrying the highest contiguous accepted msg_id.
+message AckMessage {
+  // Shard the ack is addressed to (the original sender).
+  uint64 shard_id = 1;
+  // Highest contiguous accepted msg_id.
+  uint64 acked_msg_id = 2;
+}

--- a/src/settlement/messages.rs
+++ b/src/settlement/messages.rs
@@ -1,0 +1,73 @@
+//! Cross-shard settlement message types and their wire codec.
+//!
+//! The canonical schema lives in [`messages.proto`](./messages.proto). To keep
+//! the build free of a `protoc`/`prost` toolchain dependency (the release image
+//! ships no protobuf compiler), the wire form is a small, explicit little-endian
+//! binary encoding implemented here. The struct layout matches the `.proto`
+//! definitions field-for-field so a protobuf backend can be swapped in later
+//! without touching callers.
+
+/// A single settlement payload routed from one shard to another.
+///
+/// `msg_id` is monotonically increasing **per (source shard, destination
+/// shard)** stream and is the basis for deduplication and acknowledgement.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SettlementMessage {
+    /// Destination shard this message is addressed to.
+    pub shard_id: u64,
+    /// Monotonic per-stream sequence id.
+    pub msg_id: u64,
+    /// Opaque settlement payload (avg 256 B, max 4 KB).
+    pub payload: Vec<u8>,
+}
+
+/// Credit replenishment sent by the receiver back to the sender after it has
+/// processed a batch of messages.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CreditGrant {
+    /// Shard the grant is addressed to (the original sender).
+    pub shard_id: u64,
+    /// Number of additional credits granted.
+    pub delta: u32,
+}
+
+/// Acknowledgement carrying the highest contiguous `msg_id` the receiver has
+/// durably accepted. Everything at or below this id may be released by the
+/// sender's retransmission tracker.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AckMessage {
+    /// Shard the ack is addressed to (the original sender).
+    pub shard_id: u64,
+    /// Highest contiguous accepted `msg_id`.
+    pub acked_msg_id: u64,
+}
+
+impl SettlementMessage {
+    /// Serialize to the durable-queue / wire byte form:
+    /// `[u64 shard_id][u64 msg_id][u32 payload_len][payload]` (all little-endian).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(20 + self.payload.len());
+        buf.extend_from_slice(&self.shard_id.to_le_bytes());
+        buf.extend_from_slice(&self.msg_id.to_le_bytes());
+        buf.extend_from_slice(&(self.payload.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&self.payload);
+        buf
+    }
+
+    /// Parse a message produced by [`Self::to_bytes`]. Returns `None` on any
+    /// truncation or length mismatch.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 20 {
+            return None;
+        }
+        let shard_id = u64::from_le_bytes(bytes[0..8].try_into().ok()?);
+        let msg_id = u64::from_le_bytes(bytes[8..16].try_into().ok()?);
+        let payload_len = u32::from_le_bytes(bytes[16..20].try_into().ok()?) as usize;
+        let payload = bytes.get(20..20 + payload_len)?.to_vec();
+        Some(Self {
+            shard_id,
+            msg_id,
+            payload,
+        })
+    }
+}

--- a/src/settlement/mod.rs
+++ b/src/settlement/mod.rs
@@ -1,4 +1,8 @@
 pub mod attestation_verifier;
+pub mod credit_flow;
+pub mod executor;
 pub mod merkle;
+pub mod messages;
 pub mod queue;
+pub mod shard_router;
 pub mod submitter;

--- a/src/settlement/shard_router.rs
+++ b/src/settlement/shard_router.rs
@@ -1,0 +1,353 @@
+//! Credit-controlled routing of cross-shard settlement messages.
+//!
+//! [`ShardSender`] is the egress side for one destination shard: it consumes
+//! credits, buffers in memory, spills to the durable queue under pressure, and
+//! forwards via a pluggable [`MessageSink`] (the "network"). [`ShardReceiver`]
+//! is the ingress side: it deduplicates by `msg_id`, acknowledges the highest
+//! contiguous id, and emits a [`CreditGrant`] every `grant_batch` messages.
+//! [`ShardRouter`] owns the per-destination senders and routes acks/grants back
+//! to them.
+
+use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::io;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use parking_lot::Mutex;
+
+use super::credit_flow::{CreditConfig, CreditFlowController};
+use super::messages::{AckMessage, CreditGrant, SettlementMessage};
+use crate::storage::durable_queue::DurableQueue;
+
+/// The transport over which a [`ShardSender`] forwards messages. Implementations
+/// model the inter-shard network (an mpsc channel, RPC, etc.).
+#[async_trait]
+pub trait MessageSink: Send + Sync {
+    /// Deliver `msg` toward its destination shard. Delivery may be lossy; the
+    /// retransmission timer recovers dropped messages.
+    async fn deliver(&self, msg: SettlementMessage);
+}
+
+/// Egress side for a single destination shard.
+pub struct ShardSender {
+    dest_shard: u64,
+    credit: Arc<CreditFlowController>,
+    durable: Arc<dyn DurableQueue>,
+    outbound: Mutex<VecDeque<SettlementMessage>>,
+    /// Forwarded-but-unacknowledged messages, retained for retransmission.
+    sent_log: Mutex<BTreeMap<u64, SettlementMessage>>,
+    next_msg_id: AtomicU64,
+    config: CreditConfig,
+}
+
+impl ShardSender {
+    /// Create a sender targeting `dest_shard`.
+    pub fn new(
+        dest_shard: u64,
+        credit: Arc<CreditFlowController>,
+        durable: Arc<dyn DurableQueue>,
+        config: CreditConfig,
+    ) -> Self {
+        Self {
+            dest_shard,
+            credit,
+            durable,
+            outbound: Mutex::new(VecDeque::new()),
+            sent_log: Mutex::new(BTreeMap::new()),
+            next_msg_id: AtomicU64::new(0),
+            config,
+        }
+    }
+
+    /// The credit controller backing this sender.
+    pub fn credit(&self) -> &Arc<CreditFlowController> {
+        &self.credit
+    }
+
+    fn next_id(&self) -> u64 {
+        self.next_msg_id.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Enqueue `payload` for delivery, assigning the next `msg_id`.
+    ///
+    /// Buffers in memory when a credit is available and there is room; otherwise
+    /// spills to the durable queue; and only blocks (backpressure to ingestion)
+    /// once the durable queue is also full.
+    pub async fn send(&self, payload: Vec<u8>) -> io::Result<u64> {
+        let msg_id = self.next_id();
+        let msg = SettlementMessage {
+            shard_id: self.dest_shard,
+            msg_id,
+            payload,
+        };
+
+        let has_room = self.outbound.lock().len() < self.config.in_memory_buffer;
+        if has_room && self.credit.try_acquire(1) {
+            self.outbound.lock().push_back(msg);
+        } else if self.durable.len(self.dest_shard) < self.config.durable_queue_max {
+            self.durable.push(self.dest_shard, &msg)?;
+        } else {
+            self.credit.wait_for_credits(1).await;
+            self.outbound.lock().push_back(msg);
+        }
+        Ok(msg_id)
+    }
+
+    /// Promote any spilled messages back into the in-memory buffer (subject to
+    /// room and credit) and forward everything currently buffered through
+    /// `sink`. Returns the number of messages forwarded.
+    pub async fn drain_once(&self, sink: &dyn MessageSink) -> io::Result<usize> {
+        loop {
+            let room = {
+                let buf = self.outbound.lock();
+                self.config.in_memory_buffer.saturating_sub(buf.len())
+            };
+            if room == 0 || self.durable.is_empty(self.dest_shard) {
+                break;
+            }
+            if !self.credit.try_acquire(1) {
+                break;
+            }
+            match self
+                .durable
+                .pop_batch(self.dest_shard, 1)?
+                .into_iter()
+                .next()
+            {
+                Some(m) => self.outbound.lock().push_back(m),
+                None => {
+                    // Nothing to promote after all; hand the credit back.
+                    self.credit.grant_credits(1);
+                    break;
+                }
+            }
+        }
+
+        let mut forwarded = 0;
+        loop {
+            let next = { self.outbound.lock().pop_front() };
+            let Some(msg) = next else { break };
+            let id = msg.msg_id;
+            self.sent_log.lock().insert(id, msg.clone());
+            self.credit.record_pending(id);
+            sink.deliver(msg).await;
+            forwarded += 1;
+        }
+        Ok(forwarded)
+    }
+
+    /// Retransmit every message whose ack has timed out. Receivers deduplicate,
+    /// so re-delivery is safe.
+    pub async fn retransmit_timed_out(&self, sink: &dyn MessageSink) -> usize {
+        let ids = self.credit.timed_out();
+        let mut resent = 0;
+        for id in ids {
+            let msg = self.sent_log.lock().get(&id).cloned();
+            if let Some(msg) = msg {
+                sink.deliver(msg).await;
+                resent += 1;
+            }
+        }
+        resent
+    }
+
+    /// Apply an incoming ack: advance the credit watermark and drop acknowledged
+    /// messages from the retransmission log.
+    pub fn handle_ack(&self, acked_msg_id: u64) {
+        self.credit.process_ack(acked_msg_id);
+        self.sent_log.lock().retain(|id, _| *id > acked_msg_id);
+    }
+
+    /// Total messages still buffered in memory awaiting forwarding.
+    pub fn buffered_len(&self) -> usize {
+        self.outbound.lock().len()
+    }
+
+    /// Messages spilled to the durable queue for this destination.
+    pub fn durable_len(&self) -> usize {
+        self.durable.len(self.dest_shard)
+    }
+
+    /// Messages forwarded but not yet acknowledged.
+    pub fn unacked_len(&self) -> usize {
+        self.sent_log.lock().len()
+    }
+}
+
+/// Per-source receiver state guarded by a single lock to keep dedup, watermark,
+/// and grant accounting consistent.
+struct ReceiverState {
+    /// Accepted ids strictly above `contiguous` (the out-of-order window).
+    gap: HashSet<u64>,
+    /// Highest contiguous accepted `msg_id` (0 = none).
+    contiguous: u64,
+    processed_since_grant: u32,
+    total_accepted: u64,
+    delivered: Vec<SettlementMessage>,
+}
+
+/// The result of feeding one message to a [`ShardReceiver`].
+#[derive(Clone, Debug)]
+pub struct ReceiverOutcome {
+    /// Acknowledgement to send back to the sender.
+    pub ack: AckMessage,
+    /// Credit grant to send back, if a batch boundary was crossed.
+    pub grant: Option<CreditGrant>,
+    /// Whether the message was a duplicate (already accepted).
+    pub duplicate: bool,
+}
+
+/// Ingress side for messages arriving at this shard.
+pub struct ShardReceiver {
+    /// This receiver's own shard id; used to address acks/grants back so the
+    /// sender can route them to the correct egress stream.
+    shard_id: u64,
+    state: Mutex<ReceiverState>,
+    config: CreditConfig,
+}
+
+impl ShardReceiver {
+    /// Create a receiver for the local `shard_id`.
+    pub fn new(shard_id: u64, config: CreditConfig) -> Self {
+        Self {
+            shard_id,
+            state: Mutex::new(ReceiverState {
+                gap: HashSet::new(),
+                contiguous: 0,
+                processed_since_grant: 0,
+                total_accepted: 0,
+                delivered: Vec::new(),
+            }),
+            config,
+        }
+    }
+
+    /// Accept a message: deduplicate, advance the contiguous watermark, and emit
+    /// an ack (always) plus a credit grant (every `grant_batch` new messages).
+    pub fn on_message(&self, msg: SettlementMessage) -> ReceiverOutcome {
+        let id = msg.msg_id;
+        let mut st = self.state.lock();
+
+        if id <= st.contiguous || st.gap.contains(&id) {
+            let ack = AckMessage {
+                shard_id: self.shard_id,
+                acked_msg_id: st.contiguous,
+            };
+            return ReceiverOutcome {
+                ack,
+                grant: None,
+                duplicate: true,
+            };
+        }
+
+        st.gap.insert(id);
+        let mut c = st.contiguous;
+        while st.gap.remove(&(c + 1)) {
+            c += 1;
+        }
+        st.contiguous = c;
+        st.total_accepted += 1;
+        st.delivered.push(msg);
+
+        st.processed_since_grant += 1;
+        let grant = if st.processed_since_grant >= self.config.grant_batch {
+            st.processed_since_grant -= self.config.grant_batch;
+            Some(CreditGrant {
+                shard_id: self.shard_id,
+                delta: self.config.grant_batch,
+            })
+        } else {
+            None
+        };
+
+        let ack = AckMessage {
+            shard_id: self.shard_id,
+            acked_msg_id: c,
+        };
+        ReceiverOutcome {
+            ack,
+            grant,
+            duplicate: false,
+        }
+    }
+
+    /// Total distinct messages accepted (exactly-once delivered to the app).
+    pub fn accepted_count(&self) -> u64 {
+        self.state.lock().total_accepted
+    }
+
+    /// Highest contiguous accepted `msg_id`.
+    pub fn contiguous_watermark(&self) -> u64 {
+        self.state.lock().contiguous
+    }
+
+    /// Drain and return all messages delivered to the application so far.
+    pub fn take_delivered(&self) -> Vec<SettlementMessage> {
+        std::mem::take(&mut self.state.lock().delivered)
+    }
+}
+
+/// Owns the per-destination senders for a node and routes acks/grants back.
+pub struct ShardRouter {
+    local_shard: u64,
+    config: CreditConfig,
+    durable: Arc<dyn DurableQueue>,
+    senders: DashMap<u64, Arc<ShardSender>>,
+}
+
+impl ShardRouter {
+    /// Create a router for `local_shard` using `durable` for spillover.
+    pub fn new(local_shard: u64, durable: Arc<dyn DurableQueue>, config: CreditConfig) -> Self {
+        Self {
+            local_shard,
+            config,
+            durable,
+            senders: DashMap::new(),
+        }
+    }
+
+    /// This node's shard id.
+    pub fn local_shard(&self) -> u64 {
+        self.local_shard
+    }
+
+    /// Get (creating on first use) the egress sender for `dest_shard`.
+    pub fn sender(&self, dest_shard: u64) -> Arc<ShardSender> {
+        let entry = self.senders.entry(dest_shard).or_insert_with(|| {
+            let credit = Arc::new(CreditFlowController::new(dest_shard, self.config));
+            Arc::new(ShardSender::new(
+                dest_shard,
+                credit,
+                self.durable.clone(),
+                self.config,
+            ))
+        });
+        entry.value().clone()
+    }
+
+    /// Enqueue `payload` for `dest_shard`.
+    pub async fn send(&self, dest_shard: u64, payload: Vec<u8>) -> io::Result<u64> {
+        self.sender(dest_shard).send(payload).await
+    }
+
+    /// Drain and forward buffered/spilled messages for `dest_shard`.
+    pub async fn drain(&self, dest_shard: u64, sink: &dyn MessageSink) -> io::Result<usize> {
+        self.sender(dest_shard).drain_once(sink).await
+    }
+
+    /// Route an incoming credit grant to the sender it addresses.
+    pub fn on_credit_grant(&self, grant: CreditGrant) {
+        if let Some(sender) = self.senders.get(&grant.shard_id) {
+            sender.credit().grant_credits(grant.delta);
+        }
+    }
+
+    /// Route an incoming ack to the sender it addresses.
+    pub fn on_ack(&self, ack: AckMessage) {
+        if let Some(sender) = self.senders.get(&ack.shard_id) {
+            sender.handle_ack(ack.acked_msg_id);
+        }
+    }
+}

--- a/src/storage/durable_queue.rs
+++ b/src/storage/durable_queue.rs
@@ -1,0 +1,218 @@
+//! Disk-backed durable spillover queue for cross-shard settlement messages.
+//!
+//! When a shard's in-memory buffer is exhausted, the credit-flow controller
+//! spills messages here instead of dropping them or blocking ingestion. The
+//! queue is FIFO per shard.
+//!
+//! The blueprint (issue #54) calls for a RocksDB column-family-per-shard
+//! backend. To avoid pulling a C++/`librocksdb-sys` build dependency into the
+//! release image, this module defines a [`DurableQueue`] trait with two
+//! self-contained, dependency-free implementations:
+//!
+//! * [`FileDurableQueue`] — one append-structured log file per shard, providing
+//!   real on-disk durability and FIFO `pop`.
+//! * [`InMemoryDurableQueue`] — a process-memory queue used by tests and as a
+//!   default when no spill directory is configured.
+//!
+//! A RocksDB backend can be added later as a third `DurableQueue` impl without
+//! touching callers.
+
+use std::collections::VecDeque;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use dashmap::DashMap;
+use parking_lot::Mutex;
+
+use crate::settlement::messages::SettlementMessage;
+
+/// FIFO, per-shard durable queue used for spillover under backpressure.
+pub trait DurableQueue: Send + Sync {
+    /// Append a message to the tail of `shard_id`'s queue.
+    fn push(&self, shard_id: u64, msg: &SettlementMessage) -> io::Result<()>;
+
+    /// Remove and return up to `count` messages from the head of `shard_id`'s
+    /// queue, oldest first. Returns fewer than `count` (possibly zero) when the
+    /// queue drains.
+    fn pop_batch(&self, shard_id: u64, count: usize) -> io::Result<Vec<SettlementMessage>>;
+
+    /// Number of messages currently queued for `shard_id`.
+    fn len(&self, shard_id: u64) -> usize;
+
+    /// Whether `shard_id`'s queue is empty.
+    fn is_empty(&self, shard_id: u64) -> bool {
+        self.len(shard_id) == 0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation
+// ---------------------------------------------------------------------------
+
+/// Process-memory durable queue. Not crash-safe; intended for tests and for
+/// deployments without a configured spill directory.
+#[derive(Default)]
+pub struct InMemoryDurableQueue {
+    shards: DashMap<u64, Mutex<VecDeque<SettlementMessage>>>,
+}
+
+impl InMemoryDurableQueue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl DurableQueue for InMemoryDurableQueue {
+    fn push(&self, shard_id: u64, msg: &SettlementMessage) -> io::Result<()> {
+        self.shards
+            .entry(shard_id)
+            .or_default()
+            .lock()
+            .push_back(msg.clone());
+        Ok(())
+    }
+
+    fn pop_batch(&self, shard_id: u64, count: usize) -> io::Result<Vec<SettlementMessage>> {
+        let mut out = Vec::new();
+        if let Some(entry) = self.shards.get(&shard_id) {
+            let mut q = entry.lock();
+            for _ in 0..count {
+                match q.pop_front() {
+                    Some(m) => out.push(m),
+                    None => break,
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    fn len(&self, shard_id: u64) -> usize {
+        self.shards
+            .get(&shard_id)
+            .map(|e| e.lock().len())
+            .unwrap_or(0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// File-backed implementation
+// ---------------------------------------------------------------------------
+
+/// Per-shard on-disk state: a single log file with independent read/write
+/// cursors. Records are framed as `[u32 len][message bytes]`.
+struct ShardLog {
+    file: File,
+    read_pos: u64,
+    write_pos: u64,
+    count: usize,
+}
+
+/// Append-structured-log durable queue with one file per shard under a base
+/// directory. Provides FIFO semantics with real on-disk persistence.
+pub struct FileDurableQueue {
+    dir: PathBuf,
+    shards: DashMap<u64, Mutex<ShardLog>>,
+}
+
+impl FileDurableQueue {
+    /// Open (creating if necessary) a durable queue rooted at `dir`.
+    pub fn open(dir: impl AsRef<Path>) -> io::Result<Self> {
+        let dir = dir.as_ref().to_path_buf();
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self {
+            dir,
+            shards: DashMap::new(),
+        })
+    }
+
+    fn shard_path(&self, shard_id: u64) -> PathBuf {
+        self.dir.join(format!("shard_{shard_id:020}.log"))
+    }
+
+    /// Borrow (opening on first use) the log for `shard_id` and run `f` with it
+    /// held under its mutex.
+    fn with_shard<R>(
+        &self,
+        shard_id: u64,
+        f: impl FnOnce(&mut ShardLog) -> io::Result<R>,
+    ) -> io::Result<R> {
+        if !self.shards.contains_key(&shard_id) {
+            let file = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(self.shard_path(shard_id))?;
+            let write_pos = file.metadata()?.len();
+            self.shards.entry(shard_id).or_insert_with(|| {
+                Mutex::new(ShardLog {
+                    file,
+                    read_pos: 0,
+                    write_pos,
+                    count: 0,
+                })
+            });
+        }
+        let entry = self
+            .shards
+            .get(&shard_id)
+            .expect("shard log inserted above");
+        let mut log = entry.lock();
+        f(&mut log)
+    }
+}
+
+impl DurableQueue for FileDurableQueue {
+    fn push(&self, shard_id: u64, msg: &SettlementMessage) -> io::Result<()> {
+        let bytes = msg.to_bytes();
+        let len = u32::try_from(bytes.len())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "message too large"))?;
+        self.with_shard(shard_id, |log| {
+            log.file.seek(SeekFrom::Start(log.write_pos))?;
+            log.file.write_all(&len.to_le_bytes())?;
+            log.file.write_all(&bytes)?;
+            log.file.flush()?;
+            log.write_pos += 4 + bytes.len() as u64;
+            log.count += 1;
+            Ok(())
+        })
+    }
+
+    fn pop_batch(&self, shard_id: u64, count: usize) -> io::Result<Vec<SettlementMessage>> {
+        self.with_shard(shard_id, |log| {
+            let mut out = Vec::new();
+            for _ in 0..count {
+                if log.read_pos >= log.write_pos {
+                    break;
+                }
+                log.file.seek(SeekFrom::Start(log.read_pos))?;
+                let mut len_buf = [0u8; 4];
+                log.file.read_exact(&mut len_buf)?;
+                let len = u32::from_le_bytes(len_buf) as usize;
+                let mut rec = vec![0u8; len];
+                log.file.read_exact(&mut rec)?;
+                let msg = SettlementMessage::from_bytes(&rec).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "corrupt durable record")
+                })?;
+                out.push(msg);
+                log.read_pos += 4 + len as u64;
+                log.count = log.count.saturating_sub(1);
+            }
+            // Reclaim disk space once fully drained.
+            if log.read_pos >= log.write_pos {
+                log.file.set_len(0)?;
+                log.read_pos = 0;
+                log.write_pos = 0;
+            }
+            Ok(out)
+        })
+    }
+
+    fn len(&self, shard_id: u64) -> usize {
+        self.shards
+            .get(&shard_id)
+            .map(|e| e.lock().count)
+            .unwrap_or(0)
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,6 @@
+//! Persistence backends for the settlement pipeline.
+//!
+//! Currently exposes the disk-backed spillover queue used by the cross-shard
+//! credit-flow protocol (see [`durable_queue`]).
+
+pub mod durable_queue;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod api_tests;
 pub mod gateway_tests;
+pub mod settlement;
 pub mod soroban_tests;
 pub mod tariffs_tests;
 pub mod time_series_tests;

--- a/tests/settlement/credit_flow_stress_test.rs
+++ b/tests/settlement/credit_flow_stress_test.rs
@@ -38,7 +38,7 @@ impl MessageSink for LossySink {
         // Drop each `drop_modulo`-th id exactly once: `insert` returns true the
         // first time we see it, so that first delivery attempt is dropped.
         if self.drop_modulo != 0
-            && id % self.drop_modulo == 0
+            && id.is_multiple_of(self.drop_modulo)
             && self.dropped_once.lock().insert(id)
         {
             return;

--- a/tests/settlement/credit_flow_stress_test.rs
+++ b/tests/settlement/credit_flow_stress_test.rs
@@ -1,0 +1,247 @@
+//! Stress/integration tests for the cross-shard credit-flow protocol (issue #54).
+//!
+//! These tests are deterministic on purpose: a fixed (not random) packet-loss
+//! pattern, a zero ack-timeout so retransmission is driven by the pump loop
+//! rather than wall-clock time, and a bounded convergence loop. That keeps them
+//! fast and flake-free in CI while still exercising every invariant: credit
+//! flow, durable spillover, exactly-once delivery, lossy retransmission, and
+//! full backlog drain.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+
+use utility_backend::settlement::credit_flow::{CreditConfig, CreditFlowController};
+use utility_backend::settlement::messages::SettlementMessage;
+use utility_backend::settlement::shard_router::{MessageSink, ShardReceiver, ShardRouter};
+use utility_backend::storage::durable_queue::{
+    DurableQueue, FileDurableQueue, InMemoryDurableQueue,
+};
+
+/// A lossy in-process network: forwards to the destination receiver and feeds
+/// the resulting ack/grant straight back to the sending router. Each id whose
+/// `id % drop_modulo == 0` is dropped exactly once (its first delivery attempt)
+/// to exercise timeout-based retransmission.
+struct LossySink {
+    receiver: Arc<ShardReceiver>,
+    sender_router: Arc<ShardRouter>,
+    dropped_once: Mutex<HashSet<u64>>,
+    drop_modulo: u64,
+}
+
+#[async_trait]
+impl MessageSink for LossySink {
+    async fn deliver(&self, msg: SettlementMessage) {
+        let id = msg.msg_id;
+        // Drop each `drop_modulo`-th id exactly once: `insert` returns true the
+        // first time we see it, so that first delivery attempt is dropped.
+        if self.drop_modulo != 0
+            && id % self.drop_modulo == 0
+            && self.dropped_once.lock().insert(id)
+        {
+            return;
+        }
+        let outcome = self.receiver.on_message(msg);
+        self.sender_router.on_ack(outcome.ack);
+        if let Some(grant) = outcome.grant {
+            self.sender_router.on_credit_grant(grant);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_burst_migration_exactly_once_with_spillover_and_drain() {
+    const NUM_SHARDS: u64 = 4;
+    const MESSAGES_PER_SHARD: u64 = 3_000;
+    const MAX_ROUNDS: u32 = 1_000_000;
+
+    // Tight credit/buffer bounds (relative to the load) so spillover to the
+    // durable queue is forced during the burst.
+    let config = CreditConfig {
+        initial_credit_balance: 500,
+        grant_batch: 100,
+        in_memory_buffer: 200,
+        durable_queue_max: 10_000_000,
+        ack_timeout: std::time::Duration::ZERO,
+    };
+
+    struct Pair {
+        dest: u64,
+        router: Arc<ShardRouter>,
+        receiver: Arc<ShardReceiver>,
+        sink: Arc<LossySink>,
+    }
+
+    let mut pairs = Vec::new();
+    for dest in 0..NUM_SHARDS {
+        let durable: Arc<dyn DurableQueue> = Arc::new(InMemoryDurableQueue::new());
+        let router = Arc::new(ShardRouter::new(dest, durable, config));
+        let receiver = Arc::new(ShardReceiver::new(dest, config));
+        let sink = Arc::new(LossySink {
+            receiver: receiver.clone(),
+            sender_router: router.clone(),
+            dropped_once: Mutex::new(HashSet::new()),
+            drop_modulo: 50, // ~2% loss on first attempt
+        });
+        pairs.push(Pair {
+            dest,
+            router,
+            receiver,
+            sink,
+        });
+    }
+
+    // Burst: each shard enqueues its whole migration batch at once.
+    for pair in &pairs {
+        for i in 0..MESSAGES_PER_SHARD {
+            pair.router
+                .send(pair.dest, i.to_le_bytes().to_vec())
+                .await
+                .expect("send");
+        }
+    }
+
+    // (c) Durable spillover must have been used during the burst.
+    let mut durable_used = false;
+    for pair in &pairs {
+        if pair.router.sender(pair.dest).durable_len() > 0 {
+            durable_used = true;
+        }
+    }
+    assert!(
+        durable_used,
+        "durable queue should absorb the burst overflow"
+    );
+
+    // Pump drain + retransmission until the system fully quiesces.
+    let mut rounds = 0u32;
+    loop {
+        rounds += 1;
+        assert!(rounds < MAX_ROUNDS, "did not converge");
+
+        let mut active = false;
+        for pair in &pairs {
+            let sender = pair.router.sender(pair.dest);
+            let forwarded = sender.drain_once(pair.sink.as_ref()).await.expect("drain");
+            let resent = sender.retransmit_timed_out(pair.sink.as_ref()).await;
+            if forwarded > 0
+                || resent > 0
+                || sender.buffered_len() > 0
+                || sender.durable_len() > 0
+                || sender.unacked_len() > 0
+            {
+                active = true;
+            }
+        }
+        if !active {
+            break;
+        }
+    }
+
+    // (d) Zero in-memory and on-disk backlog after the burst drains.
+    for pair in &pairs {
+        let sender = pair.router.sender(pair.dest);
+        assert_eq!(sender.buffered_len(), 0, "in-memory backlog not drained");
+        assert_eq!(sender.durable_len(), 0, "durable backlog not drained");
+        assert_eq!(sender.unacked_len(), 0, "unacked messages remain");
+    }
+
+    // (a) + (b) Exactly-once delivery: no loss, no duplicates.
+    for pair in &pairs {
+        assert_eq!(pair.receiver.accepted_count(), MESSAGES_PER_SHARD);
+        assert_eq!(pair.receiver.contiguous_watermark(), MESSAGES_PER_SHARD);
+
+        let delivered = pair.receiver.take_delivered();
+        assert_eq!(delivered.len() as u64, MESSAGES_PER_SHARD);
+        let ids: HashSet<u64> = delivered.iter().map(|m| m.msg_id).collect();
+        assert_eq!(ids.len() as u64, MESSAGES_PER_SHARD, "duplicate delivery");
+        for id in 1..=MESSAGES_PER_SHARD {
+            assert!(ids.contains(&id), "missing message {id}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_credit_acquire_grant_and_wait() {
+    let config = CreditConfig {
+        initial_credit_balance: 2,
+        grant_batch: 1,
+        in_memory_buffer: 10,
+        durable_queue_max: 10,
+        ack_timeout: std::time::Duration::ZERO,
+    };
+    let credit = Arc::new(CreditFlowController::new(7, config));
+
+    assert!(credit.try_acquire(2));
+    assert!(!credit.try_acquire(1));
+    assert_eq!(credit.credit_balance(), 0);
+
+    // A waiter parks until a grant arrives.
+    let waiter = {
+        let c = credit.clone();
+        tokio::spawn(async move {
+            c.wait_for_credits(1).await;
+        })
+    };
+    // Give the waiter a moment to park, then replenish.
+    tokio::task::yield_now().await;
+    credit.grant_credits(5);
+    waiter.await.unwrap();
+    // 5 granted, 1 taken by the waiter.
+    assert_eq!(credit.credit_balance(), 4);
+}
+
+#[tokio::test]
+async fn test_ack_advances_watermark_and_clears_pending() {
+    let credit = CreditFlowController::new(1, CreditConfig::default());
+    for id in 1..=5 {
+        credit.record_pending(id);
+    }
+    assert_eq!(credit.pending_count(), 5);
+
+    credit.process_ack(3);
+    assert_eq!(credit.acked_watermark(), 3);
+    assert_eq!(credit.pending_count(), 2); // ids 4 and 5 remain
+}
+
+#[test]
+fn test_file_durable_queue_fifo_and_reclaim() {
+    let dir = std::env::temp_dir().join(format!("credit_flow_dq_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let queue = FileDurableQueue::open(&dir).expect("open durable queue");
+
+    for i in 0..5u64 {
+        let msg = SettlementMessage {
+            shard_id: 9,
+            msg_id: i + 1,
+            payload: vec![i as u8; 16],
+        };
+        queue.push(9, &msg).expect("push");
+    }
+    assert_eq!(queue.len(9), 5);
+
+    let first = queue.pop_batch(9, 3).expect("pop");
+    assert_eq!(first.len(), 3);
+    assert_eq!(first[0].msg_id, 1);
+    assert_eq!(first[2].msg_id, 3);
+    assert_eq!(queue.len(9), 2);
+
+    let rest = queue.pop_batch(9, 10).expect("pop");
+    assert_eq!(rest.len(), 2);
+    assert_eq!(rest[1].msg_id, 5);
+    assert!(queue.is_empty(9));
+
+    // Queue is reusable after draining (file reclaimed).
+    let msg = SettlementMessage {
+        shard_id: 9,
+        msg_id: 99,
+        payload: vec![7; 4],
+    };
+    queue.push(9, &msg).expect("push after drain");
+    assert_eq!(queue.len(9), 1);
+    assert_eq!(queue.pop_batch(9, 1).expect("pop")[0].msg_id, 99);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/settlement/mod.rs
+++ b/tests/settlement/mod.rs
@@ -1,0 +1,1 @@
+pub mod credit_flow_stress_test;


### PR DESCRIPTION
# Unbounded Channel Backpressure Safeguard — Sliding-Window Credit Protocol for Cross-Shard Settlement (#54)

Closes #54
## What's added

| Module | Responsibility |
|---|---|
| `settlement/credit_flow.rs` | `CreditFlowController` — signed per-shard credit balance (CAS `try_acquire`, `grant_credits`, parked `wait_for_credits`), `pending_acks` tracking, ack watermark, and timeout-based retransmission set. `CreditConfig` holds the issue's bounds (100k initial credits, 1k grant batch, 200k buffer, 10M durable cap, 1s ack timeout). |
| `settlement/shard_router.rs` | `ShardSender` (acquire credit → in-memory `VecDeque` → durable spill → block only when durable is full; drainable forwarding via a pluggable `MessageSink`; retransmit timed-out messages). `ShardReceiver` (exactly-once dedup via **contiguous watermark + out-of-order gap set**, acks the highest contiguous id, emits a `CreditGrant` every `grant_batch`). `ShardRouter` routes inbound acks/grants back to the right egress stream. |
| `settlement/executor.rs` | `SettlementExecutor` — credit-controlled cross-shard submit/flush entry point (`acquire` happens inside the router for all traffic). |
| `settlement/messages.rs` + `messages.proto` | `SettlementMessage` / `CreditGrant` / `AckMessage`. The `.proto` is the canonical schema; the Rust codec is a hand-rolled little-endian encoding. |
| `storage/durable_queue.rs` | `DurableQueue` FIFO trait with a real **file-backed** impl (per-shard append log, independent read/write cursors, space reclaim on drain) and an in-memory impl. |
