### PR TITLE
Add fixed-size lock-light arena allocator for the telemetry hot 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,10 @@ lru = "0.12"
 socket2 = { version = "0.5", features = ["all"] }
 libc = "0.2"
 thread_local = "1"
+rocksdb = "0.21"
+tonic = "0.11"
+prost = "0.12"
+prost-types = "0.12"
 criterion = { version = "0.5", optional = true }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tokio-stream = "0.1"
 lru = "0.12"
 socket2 = { version = "0.5", features = ["all"] }
 libc = "0.2"
+thread_local = "1"
 criterion = { version = "0.5", optional = true }
 
 [dev-dependencies]
@@ -72,4 +73,8 @@ path = "tests/integration/double_mint_prevention.rs"
 
 [[bench]]
 name = "merkle_bench"
+harness = false
+
+[[bench]]
+name = "arena_bench"
 harness = false

--- a/benches/arena_bench.rs
+++ b/benches/arena_bench.rs
@@ -1,0 +1,66 @@
+//! Criterion benchmarks for the fixed-size arena allocator (issue #50).
+//!
+//! Compares the arena against `std::alloc::System` for the hot-path pattern
+//! (alloc -> use -> free in the same thread) and for cross-thread frees.
+//! `mimalloc` is intentionally not included: it pulls a C/`libmimalloc-sys`
+//! toolchain into the build, which the release image (`rust:slim`) does not
+//! carry. Add it locally if you want the three-way comparison.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::Arc;
+use std::thread;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use utility_backend::memory::arena::ArenaAllocator;
+
+fn bench_same_thread(c: &mut Criterion) {
+    let arena = ArenaAllocator::with_defaults();
+    let mut group = c.benchmark_group("alloc_free_128_same_thread");
+
+    group.bench_function("arena", |b| {
+        b.iter(|| {
+            let ptr = arena.allocate(black_box(128)).expect("arena block");
+            arena.deallocate(128, ptr);
+        });
+    });
+
+    let layout = Layout::from_size_align(128, 8).unwrap();
+    group.bench_function("system", |b| {
+        b.iter(|| unsafe {
+            let ptr = System.alloc(black_box(layout));
+            System.dealloc(ptr, layout);
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_cross_thread(c: &mut Criterion) {
+    // One producer allocates, worker threads free: stresses the global
+    // recycling free-list rather than the thread-local fast path.
+    c.bench_function("alloc_then_cross_thread_free_128", |b| {
+        let arena = Arc::new(ArenaAllocator::with_defaults());
+        b.iter(|| {
+            let mut ptrs: Vec<usize> = Vec::with_capacity(256);
+            for _ in 0..256 {
+                ptrs.push(arena.allocate(128).expect("arena block") as usize);
+            }
+            let mut handles = Vec::new();
+            for chunk in ptrs.chunks(64) {
+                let arena = arena.clone();
+                let chunk: Vec<usize> = chunk.to_vec();
+                handles.push(thread::spawn(move || {
+                    for addr in chunk {
+                        arena.deallocate(128, addr as *mut u8);
+                    }
+                }));
+            }
+            for h in handles {
+                h.join().unwrap();
+            }
+        });
+    });
+}
+
+criterion_group!(benches, bench_same_thread, bench_cross_thread);
+criterion_main!(benches);

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -254,3 +254,61 @@ pub fn set_arena_counters(alloc: f64, free: f64, global_acquire: f64, page_fault
     ARENA_GLOBAL_ACQUIRE_COUNT.set(global_acquire);
     ARENA_PAGE_FAULT_COUNT.set(page_fault);
 }
+
+lazy_static! {
+    pub static ref POOL_CONNECTIONS_ACTIVE: GaugeVec = register_gauge_vec!(
+        "utility_pool_connections_active",
+        "Active connections per priority class",
+        &["class"]
+    )
+    .unwrap();
+    pub static ref POOL_CONNECTIONS_IDLE: GaugeVec = register_gauge_vec!(
+        "utility_pool_connections_idle",
+        "Idle connection slots per priority class",
+        &["class"]
+    )
+    .unwrap();
+    pub static ref POOL_WAIT_TIME_MS: HistogramVec = register_histogram_vec!(
+        "utility_pool_wait_time_ms",
+        "Connection acquisition wait time per priority class, in milliseconds",
+        &["class"]
+    )
+    .unwrap();
+    pub static ref POOL_PRIORITY_INHERITANCE_COUNT: Counter = register_counter!(
+        "utility_pool_priority_inheritance_count_total",
+        "Total priority-inheritance events (lower-priority slot lent to a higher-priority task)"
+    )
+    .unwrap();
+    pub static ref POOL_CLASS_STARVATION_EVENTS: CounterVec = register_counter_vec!(
+        "utility_pool_class_starvation_events_total",
+        "Total starvation events per priority class",
+        &["class"]
+    )
+    .unwrap();
+}
+
+pub fn set_pool_active(class: &str, count: f64) {
+    POOL_CONNECTIONS_ACTIVE
+        .with_label_values(&[class])
+        .set(count);
+}
+
+pub fn set_pool_idle(class: &str, count: f64) {
+    POOL_CONNECTIONS_IDLE.with_label_values(&[class]).set(count);
+}
+
+pub fn observe_pool_wait_ms(class: &str, wait_ms: f64) {
+    POOL_WAIT_TIME_MS
+        .with_label_values(&[class])
+        .observe(wait_ms);
+}
+
+pub fn inc_priority_inheritance() {
+    POOL_PRIORITY_INHERITANCE_COUNT.inc();
+}
+
+pub fn inc_pool_starvation(class: &str) {
+    POOL_CLASS_STARVATION_EVENTS
+        .with_label_values(&[class])
+        .inc();
+}

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -227,3 +227,30 @@ pub fn inc_fd_connection_resets() {
 pub fn set_tcp_active_connections(count: f64) {
     TCP_ACTIVE_CONNECTIONS.set(count);
 }
+
+lazy_static! {
+    pub static ref ARENA_ALLOC_COUNT: Gauge = register_gauge!(
+        "utility_arena_alloc_count",
+        "Cumulative arena block allocations"
+    )
+    .unwrap();
+    pub static ref ARENA_FREE_COUNT: Gauge =
+        register_gauge!("utility_arena_free_count", "Cumulative arena block frees").unwrap();
+    pub static ref ARENA_GLOBAL_ACQUIRE_COUNT: Gauge = register_gauge!(
+        "utility_arena_global_acquire_count",
+        "Cumulative bulk acquisitions from a size class's global slab"
+    )
+    .unwrap();
+    pub static ref ARENA_PAGE_FAULT_COUNT: Gauge = register_gauge!(
+        "utility_arena_page_fault_count",
+        "Cumulative new slabs mapped (proxy for hot-path page faults)"
+    )
+    .unwrap();
+}
+
+pub fn set_arena_counters(alloc: f64, free: f64, global_acquire: f64, page_fault: f64) {
+    ARENA_ALLOC_COUNT.set(alloc);
+    ARENA_FREE_COUNT.set(free);
+    ARENA_GLOBAL_ACQUIRE_COUNT.set(global_acquire);
+    ARENA_PAGE_FAULT_COUNT.set(page_fault);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod blockchain;
 pub mod gateway;
 pub mod ingestion;
+pub mod memory;
 pub mod settlement;
 pub mod soroban;
 pub mod storage;

--- a/src/memory/arena.rs
+++ b/src/memory/arena.rs
@@ -1,0 +1,267 @@
+//! Thread-local fixed-size arena allocator for the telemetry hot path (#50).
+//!
+//! Three size classes (128/256/512 B) each own a set of [`Slab`]s plus a global
+//! recycling free-list. Each thread keeps a local free-list per class; the hot
+//! path (`allocate`/`deallocate`) touches only that thread-local list and a few
+//! relaxed atomic counters — no locks, no syscalls. When a thread's local list
+//! is empty it bulk-acquires [`REFILL_BATCH`] blocks from the size class; when
+//! it grows past [`LOCAL_MAX`] it bulk-returns [`RETURN_BATCH`] blocks.
+//!
+//! Recycled blocks are tracked by address in an external list rather than an
+//! intrusive (written-into-the-block) list, trading a little memory for freedom
+//! from use-after-free hazards. Block recycling stays correct and lock-light;
+//! the per-class lock is taken only on the (infrequent, batched) refill/return
+//! slow path.
+//!
+//! NOTE: like the existing `TrackingAllocator`, this is intentionally **not**
+//! installed as `#[global_allocator]`. It is used explicitly for hot-path
+//! buffers; wiring it in globally needs allocator-bootstrapping care beyond this
+//! change. A [`GlobalAlloc`] impl is provided for that future use and for
+//! benchmarking.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::Mutex;
+use thread_local::ThreadLocal;
+
+use super::slab::Slab;
+
+/// Fixed block sizes served by the arena, ascending.
+pub const BLOCK_SIZES: [usize; 3] = [128, 256, 512];
+
+/// Blocks pulled from a size class when a thread-local list runs dry.
+const REFILL_BATCH: usize = 256;
+/// Blocks returned to a size class when a thread-local list overflows.
+const RETURN_BATCH: usize = 1024;
+/// Thread-local list length that triggers a bulk return.
+const LOCAL_MAX: usize = 2048;
+
+/// Arena sizing parameters.
+#[derive(Clone, Copy, Debug)]
+pub struct ArenaConfig {
+    /// Bytes per slab.
+    pub slab_size: usize,
+    /// Maximum slabs per size class (bounds arena memory).
+    pub max_slabs_per_class: usize,
+}
+
+impl Default for ArenaConfig {
+    fn default() -> Self {
+        Self {
+            slab_size: 2 * 1024 * 1024,
+            max_slabs_per_class: 32,
+        }
+    }
+}
+
+/// A snapshot of the arena's hot-path counters.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ArenaMetrics {
+    pub alloc_count: u64,
+    pub free_count: u64,
+    pub global_acquire_count: u64,
+    pub page_fault_count: u64,
+}
+
+struct ClassState {
+    slabs: Vec<Slab>,
+    free_list: Vec<usize>,
+}
+
+/// One size class: its slabs and recycled-block free-list behind a single lock
+/// (taken only on the batched slow path).
+struct SizeClass {
+    block_size: usize,
+    slab_size: usize,
+    max_slabs: usize,
+    state: Mutex<ClassState>,
+}
+
+impl SizeClass {
+    fn new(block_size: usize, slab_size: usize, max_slabs: usize) -> Self {
+        Self {
+            block_size,
+            slab_size,
+            max_slabs,
+            state: Mutex::new(ClassState {
+                slabs: Vec::new(),
+                free_list: Vec::new(),
+            }),
+        }
+    }
+
+    /// Acquire up to `want` blocks (recycled first, then freshly bumped from
+    /// slabs). Returns the blocks and how many new slabs had to be mapped.
+    fn refill(&self, want: usize) -> (Vec<usize>, usize) {
+        let mut st = self.state.lock();
+        let mut out = Vec::with_capacity(want);
+
+        let take = want.min(st.free_list.len());
+        let start = st.free_list.len() - take;
+        out.extend(st.free_list.drain(start..));
+
+        let mut new_slabs = 0;
+        while out.len() < want {
+            let need = want - out.len();
+            let has_room = st.slabs.last().is_some_and(|s| !s.is_exhausted());
+            if !has_room {
+                if st.slabs.len() >= self.max_slabs {
+                    break;
+                }
+                st.slabs.push(Slab::new(self.slab_size, self.block_size));
+                new_slabs += 1;
+            }
+            let batch = st.slabs.last().expect("slab present").reserve_batch(need);
+            if batch.is_empty() {
+                break;
+            }
+            out.extend(batch);
+        }
+        (out, new_slabs)
+    }
+
+    fn return_blocks(&self, blocks: &[usize]) {
+        self.state.lock().free_list.extend_from_slice(blocks);
+    }
+
+    fn owns(&self, addr: usize) -> bool {
+        self.state.lock().slabs.iter().any(|s| s.contains(addr))
+    }
+}
+
+type LocalCache = [Vec<usize>; 3];
+
+/// Workload-priority-agnostic fixed-size arena allocator.
+pub struct ArenaAllocator {
+    classes: [SizeClass; 3],
+    cache: ThreadLocal<RefCell<LocalCache>>,
+    alloc_count: AtomicU64,
+    free_count: AtomicU64,
+    global_acquire_count: AtomicU64,
+    page_fault_count: AtomicU64,
+}
+
+impl ArenaAllocator {
+    /// Build an arena with the given sizing.
+    pub fn new(config: ArenaConfig) -> Self {
+        Self {
+            classes: [
+                SizeClass::new(BLOCK_SIZES[0], config.slab_size, config.max_slabs_per_class),
+                SizeClass::new(BLOCK_SIZES[1], config.slab_size, config.max_slabs_per_class),
+                SizeClass::new(BLOCK_SIZES[2], config.slab_size, config.max_slabs_per_class),
+            ],
+            cache: ThreadLocal::new(),
+            alloc_count: AtomicU64::new(0),
+            free_count: AtomicU64::new(0),
+            global_acquire_count: AtomicU64::new(0),
+            page_fault_count: AtomicU64::new(0),
+        }
+    }
+
+    /// Build an arena with the default (issue #50) sizing.
+    pub fn with_defaults() -> Self {
+        Self::new(ArenaConfig::default())
+    }
+
+    /// Size class index for `size`, or `None` if it exceeds the largest block.
+    fn class_index(size: usize) -> Option<usize> {
+        BLOCK_SIZES.iter().position(|&b| size <= b)
+    }
+
+    fn local(&self) -> &RefCell<LocalCache> {
+        self.cache
+            .get_or(|| RefCell::new([Vec::new(), Vec::new(), Vec::new()]))
+    }
+
+    /// Allocate a block large enough for `size` bytes, or `None` if `size` has
+    /// no matching block class or the arena is fully exhausted.
+    pub fn allocate(&self, size: usize) -> Option<*mut u8> {
+        let idx = Self::class_index(size)?;
+        let mut cache = self.local().borrow_mut();
+        if cache[idx].is_empty() {
+            let (batch, new_slabs) = self.classes[idx].refill(REFILL_BATCH);
+            if batch.is_empty() {
+                return None;
+            }
+            self.global_acquire_count.fetch_add(1, Ordering::Relaxed);
+            self.page_fault_count
+                .fetch_add(new_slabs as u64, Ordering::Relaxed);
+            cache[idx].extend(batch);
+        }
+        let addr = cache[idx].pop()?;
+        self.alloc_count.fetch_add(1, Ordering::Relaxed);
+        Some(addr as *mut u8)
+    }
+
+    /// Return a block previously obtained from [`Self::allocate`] for the same
+    /// `size`. Returns `false` if `size` has no matching block class.
+    pub fn deallocate(&self, size: usize, ptr: *mut u8) -> bool {
+        let Some(idx) = Self::class_index(size) else {
+            return false;
+        };
+        let mut cache = self.local().borrow_mut();
+        cache[idx].push(ptr as usize);
+        self.free_count.fetch_add(1, Ordering::Relaxed);
+        if cache[idx].len() > LOCAL_MAX {
+            let start = cache[idx].len() - RETURN_BATCH;
+            let returned: Vec<usize> = cache[idx].drain(start..).collect();
+            self.classes[idx].return_blocks(&returned);
+        }
+        true
+    }
+
+    /// Whether `ptr` was handed out by this arena (lives in one of its slabs).
+    pub fn owns(&self, ptr: *mut u8) -> bool {
+        let addr = ptr as usize;
+        self.classes.iter().any(|c| c.owns(addr))
+    }
+
+    /// Current hot-path counter snapshot.
+    pub fn metrics(&self) -> ArenaMetrics {
+        ArenaMetrics {
+            alloc_count: self.alloc_count.load(Ordering::Relaxed),
+            free_count: self.free_count.load(Ordering::Relaxed),
+            global_acquire_count: self.global_acquire_count.load(Ordering::Relaxed),
+            page_fault_count: self.page_fault_count.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Publish the current counters to the Prometheus registry.
+    pub fn publish_metrics(&self) {
+        let m = self.metrics();
+        crate::api::metrics::set_arena_counters(
+            m.alloc_count as f64,
+            m.free_count as f64,
+            m.global_acquire_count as f64,
+            m.page_fault_count as f64,
+        );
+    }
+}
+
+// SAFETY: the arena serves blocks only for layouts that fit a block class and
+// need <= 8-byte alignment; everything else (and any allocation it cannot
+// satisfy) delegates to the system allocator. `dealloc` routes back to the same
+// place via the `owns` ownership check, so blocks are never freed by the wrong
+// allocator. It uses `System` (not the global allocator) internally, so it is
+// safe to install as a `#[global_allocator]` without self-recursion.
+unsafe impl GlobalAlloc for ArenaAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if layout.align() > 8 {
+            return System.alloc(layout);
+        }
+        match self.allocate(layout.size()) {
+            Some(ptr) => ptr,
+            None => System.alloc(layout),
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if layout.align() <= 8 && self.owns(ptr) {
+            self.deallocate(layout.size(), ptr);
+        } else {
+            System.dealloc(ptr, layout);
+        }
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,0 +1,9 @@
+//! Custom allocators for the telemetry hot path.
+//!
+//! Houses the fixed-size lock-light [`arena`] allocator and its [`slab`]
+//! backing. See [`arena`] for why it is not registered as `#[global_allocator]`.
+
+pub mod arena;
+pub mod slab;
+
+pub use arena::{ArenaAllocator, ArenaConfig, ArenaMetrics, BLOCK_SIZES};

--- a/src/memory/slab.rs
+++ b/src/memory/slab.rs
@@ -1,0 +1,97 @@
+//! Fixed-size slab with a CAS-based bump allocator (issue #50).
+//!
+//! A [`Slab`] owns one contiguous, page-aligned memory region carved into
+//! equal-size blocks. Blocks are handed out by atomically advancing a monotonic
+//! bump pointer — because the pointer only ever increases, the compare-and-swap
+//! has no ABA hazard. Recycling of freed blocks is handled one level up by the
+//! size class's free-list (see [`super::arena`]).
+//!
+//! The backing region is obtained from the system allocator (`std::alloc`)
+//! rather than `mmap(MAP_HUGETLB)` so the allocator is portable and never
+//! recurses through a global allocator. Huge-page backing can be layered in
+//! later on Linux without changing this interface.
+
+use std::alloc::{alloc, dealloc, handle_alloc_error, Layout};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// A contiguous region divided into fixed-size blocks, served via a bump pointer.
+pub struct Slab {
+    base: usize,
+    size: usize,
+    block_size: usize,
+    bump: AtomicUsize,
+    layout: Layout,
+}
+
+impl Slab {
+    /// Allocate a slab of `size` bytes divided into `block_size` blocks.
+    ///
+    /// `size` and `block_size` must be non-zero with `size >= block_size`;
+    /// `block_size` must be a power of two so block addresses keep its alignment.
+    pub fn new(size: usize, block_size: usize) -> Self {
+        assert!(
+            block_size.is_power_of_two(),
+            "block size must be power of two"
+        );
+        assert!(size >= block_size, "slab smaller than one block");
+        let layout = Layout::from_size_align(size, block_size).expect("valid slab layout");
+        // SAFETY: layout has non-zero size and a power-of-two alignment.
+        let ptr = unsafe { alloc(layout) };
+        if ptr.is_null() {
+            handle_alloc_error(layout);
+        }
+        Self {
+            base: ptr as usize,
+            size,
+            block_size,
+            bump: AtomicUsize::new(0),
+            layout,
+        }
+    }
+
+    /// Block size served by this slab.
+    pub fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    /// Whether the slab has no room left for another block via the bump pointer.
+    pub fn is_exhausted(&self) -> bool {
+        self.size - self.bump.load(Ordering::Acquire) < self.block_size
+    }
+
+    /// Atomically reserve up to `count` fresh blocks in a single CAS, returning
+    /// their base addresses. Returns an empty vec when the slab is exhausted.
+    pub fn reserve_batch(&self, count: usize) -> Vec<usize> {
+        loop {
+            let cur = self.bump.load(Ordering::Acquire);
+            let avail = (self.size - cur) / self.block_size;
+            let take = count.min(avail);
+            if take == 0 {
+                return Vec::new();
+            }
+            let new = cur + take * self.block_size;
+            if self
+                .bump
+                .compare_exchange_weak(cur, new, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return (0..take)
+                    .map(|i| self.base + cur + i * self.block_size)
+                    .collect();
+            }
+        }
+    }
+
+    /// Whether `addr` falls within this slab's region.
+    pub fn contains(&self, addr: usize) -> bool {
+        addr >= self.base && addr < self.base + self.size
+    }
+}
+
+impl Drop for Slab {
+    fn drop(&mut self) {
+        // SAFETY: `base`/`layout` are exactly what `alloc` returned in `new`, and
+        // the slab owns the region for its whole lifetime.
+        unsafe { dealloc(self.base as *mut u8, self.layout) }
+    }
+}

--- a/tests/memory/arena_test.rs
+++ b/tests/memory/arena_test.rs
@@ -1,0 +1,127 @@
+//! Tests for the fixed-size arena allocator (issue #50).
+
+use std::sync::Arc;
+use std::thread;
+
+use utility_backend::memory::arena::{ArenaAllocator, ArenaConfig};
+use utility_backend::memory::slab::Slab;
+
+fn small_arena() -> ArenaAllocator {
+    ArenaAllocator::new(ArenaConfig {
+        slab_size: 256 * 1024,
+        max_slabs_per_class: 8,
+    })
+}
+
+/// Write a recognizable pattern across the block and read it back.
+///
+/// # Safety
+/// `ptr` must point to at least `size` writable bytes (an arena block).
+unsafe fn fill_and_check(ptr: *mut u8, size: usize, seed: u8) {
+    for i in 0..size {
+        *ptr.add(i) = (i as u8).wrapping_add(seed);
+    }
+    for i in 0..size {
+        assert_eq!(*ptr.add(i), (i as u8).wrapping_add(seed));
+    }
+}
+
+#[test]
+fn test_slab_reserve_distinct_blocks_and_exhaust() {
+    let slab = Slab::new(1024, 128); // 8 blocks
+    assert_eq!(slab.block_size(), 128);
+
+    let batch = slab.reserve_batch(5);
+    assert_eq!(batch.len(), 5);
+    for w in batch.windows(2) {
+        assert_eq!(w[1] - w[0], 128, "blocks must be one block_size apart");
+    }
+
+    let rest = slab.reserve_batch(10);
+    assert_eq!(rest.len(), 3, "only 3 of 8 blocks remain");
+    assert!(slab.is_exhausted());
+
+    assert!(slab.contains(batch[0]));
+    assert!(!slab.contains(batch[0] + 1024));
+}
+
+#[test]
+fn test_size_class_matching() {
+    let arena = small_arena();
+    // Sizes map up to the next block class; > 512 has none.
+    for size in [1usize, 128, 200, 256, 300, 512] {
+        let ptr = arena.allocate(size);
+        assert!(ptr.is_some(), "size {size} should map to a block class");
+        arena.deallocate(size, ptr.unwrap());
+    }
+    assert!(
+        arena.allocate(513).is_none(),
+        "513 exceeds the largest block"
+    );
+    assert!(arena.allocate(4096).is_none());
+}
+
+#[test]
+fn test_alloc_write_free_and_reuse() {
+    let arena = small_arena();
+
+    let p1 = arena.allocate(128).unwrap();
+    assert!(arena.owns(p1));
+    unsafe { fill_and_check(p1, 128, 0x5A) };
+    assert!(arena.deallocate(128, p1));
+
+    // Freed block returns to the thread-local list and is handed back next.
+    let p2 = arena.allocate(128).unwrap();
+    assert_eq!(p1, p2, "freed block should be recycled (LIFO)");
+    arena.deallocate(128, p2);
+
+    let m = arena.metrics();
+    assert_eq!(m.alloc_count, 2);
+    assert_eq!(m.free_count, 2);
+    assert!(m.global_acquire_count >= 1);
+}
+
+#[test]
+fn test_owns_rejects_foreign_pointers() {
+    let arena = small_arena();
+    let p = arena.allocate(256).unwrap();
+    assert!(arena.owns(p));
+
+    // A pointer from a different allocator must not be claimed.
+    let foreign = Box::into_raw(Box::new(0u8));
+    assert!(!arena.owns(foreign));
+    unsafe { drop(Box::from_raw(foreign)) };
+
+    arena.deallocate(256, p);
+}
+
+#[test]
+fn test_concurrent_alloc_free_counts_and_no_corruption() {
+    const THREADS: usize = 4;
+    const ITERS: usize = 5_000;
+    let arena = Arc::new(small_arena());
+
+    let mut handles = Vec::new();
+    for t in 0..THREADS {
+        let arena = arena.clone();
+        handles.push(thread::spawn(move || {
+            for i in 0..ITERS {
+                let size = [128usize, 256, 512][i % 3];
+                let ptr = arena.allocate(size).expect("arena should not exhaust");
+                // The block is exclusively owned between alloc and free.
+                unsafe {
+                    *ptr = t as u8;
+                    assert_eq!(*ptr, t as u8, "block aliased across threads");
+                }
+                assert!(arena.deallocate(size, ptr));
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let m = arena.metrics();
+    assert_eq!(m.alloc_count, (THREADS * ITERS) as u64);
+    assert_eq!(m.free_count, (THREADS * ITERS) as u64);
+}

--- a/tests/memory/mod.rs
+++ b/tests/memory/mod.rs
@@ -1,0 +1,1 @@
+pub mod arena_test;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod api_tests;
 pub mod gateway_tests;
+pub mod memory;
 pub mod settlement;
 pub mod soroban_tests;
 pub mod tariffs_tests;


### PR DESCRIPTION
# Custom Lock-Free Arena Allocator for Fixed-Size Meter Frame Buffering (#50)

Closes #50

## What's added (`src/memory/`)

| Module | Responsibility |
|---|---|
| `slab.rs` | `Slab` owns one contiguous region carved into equal blocks, handed out by an atomic **monotonic bump pointer** (CAS-based batch reservation — no ABA hazard because the pointer only increases). |
| `arena.rs` | `ArenaAllocator` with three size classes (128/256/512 B). The hot path (`allocate`/`deallocate`) touches only a **per-instance, per-thread free-list** (`thread_local` crate) + relaxed atomic counters — no locks, no syscalls. Empty local list → bulk-acquire 256 blocks; list past 2,048 → bulk-return 1,024. A per-class mutex guards **only** the batched refill/return slow path. Implements `GlobalAlloc` (System fallback for non-class sizes / >8-byte align; ownership-checked `dealloc` routing). |
