### PR TITLE
Add Soroban reorg detection, rollback, and replay protection (#41)

### DIFF
--- a/src/blockchain/soroban/client.rs
+++ b/src/blockchain/soroban/client.rs
@@ -1,3 +1,4 @@
+use crate::blockchain::soroban::reorg_handler::LedgerInfo;
 use crate::soroban::rpc::{CircuitBreaker, SorobanRpcResponse};
 use serde_json::json;
 
@@ -33,5 +34,66 @@ impl SorobanClient {
         });
 
         self.circuit_breaker.call_rpc(&self.rpc_url, payload).await
+    }
+
+    /// Fetch canonical `(seq, hash)` for the inclusive ledger range, used by the
+    /// reorg handler to compare against the locally indexed chain.
+    pub async fn get_ledger_range(
+        &mut self,
+        start_seq: u64,
+        end_seq: u64,
+    ) -> Result<Vec<LedgerInfo>, &'static str> {
+        let payload = json!({
+            "jsonrpc": "2.0",
+            "id": "get_ledger_range",
+            "method": "getLedgers",
+            "params": { "startLedger": start_seq, "endLedger": end_seq }
+        });
+        let resp = self
+            .circuit_breaker
+            .call_rpc(&self.rpc_url, payload)
+            .await?;
+        let result = resp.result.ok_or("missing result")?;
+        let ledgers = result
+            .get("ledgers")
+            .and_then(|v| v.as_array())
+            .ok_or("missing ledgers array")?;
+
+        let mut out = Vec::with_capacity(ledgers.len());
+        for entry in ledgers {
+            let seq = entry
+                .get("sequence")
+                .and_then(|v| v.as_u64())
+                .ok_or("missing ledger sequence")?;
+            let hash_hex = entry
+                .get("hash")
+                .and_then(|v| v.as_str())
+                .ok_or("missing ledger hash")?;
+            let bytes = hex::decode(hash_hex).map_err(|_| "invalid ledger hash hex")?;
+            let hash: [u8; 32] = bytes.try_into().map_err(|_| "ledger hash not 32 bytes")?;
+            out.push(LedgerInfo { seq, hash });
+        }
+        Ok(out)
+    }
+
+    /// Whether `tx_hash` is included in the canonical ledger `ledger_seq`.
+    pub async fn is_tx_in_ledger(
+        &mut self,
+        tx_hash: [u8; 32],
+        ledger_seq: u64,
+    ) -> Result<bool, &'static str> {
+        let payload = json!({
+            "jsonrpc": "2.0",
+            "id": "is_tx_in_ledger",
+            "method": "getTransaction",
+            "params": { "hash": hex::encode(tx_hash) }
+        });
+        let resp = self
+            .circuit_breaker
+            .call_rpc(&self.rpc_url, payload)
+            .await?;
+        let result = resp.result.ok_or("missing result")?;
+        let included = result.get("ledger").and_then(|v| v.as_u64()) == Some(ledger_seq);
+        Ok(included)
     }
 }

--- a/src/blockchain/soroban/mod.rs
+++ b/src/blockchain/soroban/mod.rs
@@ -1,1 +1,2 @@
 pub mod client;
+pub mod reorg_handler;

--- a/src/blockchain/soroban/reorg_handler.rs
+++ b/src/blockchain/soroban/reorg_handler.rs
@@ -1,0 +1,372 @@
+//! Soroban reorg detection, rollback, and replay orchestration (#41).
+//!
+//! Soroban can produce short reorgs (1–5 ledgers) under network asynchrony,
+//! which can orphan ledgers that local settlement state already depends on. This
+//! module tracks `(ledger_seq, ledger_hash)` per settled batch, detects
+//! divergence from a trusted archival node, rolls back affected batches on the
+//! contract, and replays them under a fresh per-reorg nonce so duplicate mints
+//! are rejected.
+//!
+//! Chain access is abstracted behind [`LedgerOracle`] (canonical chain queries)
+//! and [`ReorgContract`] (rollback/replay calls) so the orchestration is unit
+//! testable without a live Soroban devnet.
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+
+use crate::storage::reorg_log::ReorgLog;
+
+/// Reason code passed to the contract's `rollback_batch`.
+pub const REORG_ROLLBACK: u32 = 1;
+
+/// A ledger's canonical identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LedgerInfo {
+    pub seq: u64,
+    pub hash: [u8; 32],
+}
+
+/// Snapshot of a settled batch, retained for rollback/replay.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BatchState {
+    pub batch_id: u64,
+    pub source_meter_ids: Vec<String>,
+    pub total_scaled_amount: u128,
+    pub ledger_seq: u64,
+    pub ledger_hash: [u8; 32],
+    pub ledger_close_time: u64,
+    pub tx_envelope_hash: [u8; 32],
+    pub state_commitment: [u8; 32],
+}
+
+impl BatchState {
+    /// Serialize to a compact little-endian byte form (the durable-store value,
+    /// standing in for the protobuf `BatchState`).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&self.batch_id.to_le_bytes());
+        buf.extend_from_slice(&(self.source_meter_ids.len() as u32).to_le_bytes());
+        for id in &self.source_meter_ids {
+            buf.extend_from_slice(&(id.len() as u32).to_le_bytes());
+            buf.extend_from_slice(id.as_bytes());
+        }
+        buf.extend_from_slice(&self.total_scaled_amount.to_le_bytes());
+        buf.extend_from_slice(&self.ledger_seq.to_le_bytes());
+        buf.extend_from_slice(&self.ledger_hash);
+        buf.extend_from_slice(&self.ledger_close_time.to_le_bytes());
+        buf.extend_from_slice(&self.tx_envelope_hash);
+        buf.extend_from_slice(&self.state_commitment);
+        buf
+    }
+
+    /// Parse a value produced by [`Self::to_bytes`]; `None` on truncation.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        let mut pos = 0usize;
+        let take = |bytes: &[u8], pos: &mut usize, n: usize| -> Option<Vec<u8>> {
+            let slice = bytes.get(*pos..*pos + n)?.to_vec();
+            *pos += n;
+            Some(slice)
+        };
+        let batch_id = u64::from_le_bytes(take(bytes, &mut pos, 8)?.try_into().ok()?);
+        let count = u32::from_le_bytes(take(bytes, &mut pos, 4)?.try_into().ok()?) as usize;
+        let mut source_meter_ids = Vec::with_capacity(count);
+        for _ in 0..count {
+            let len = u32::from_le_bytes(take(bytes, &mut pos, 4)?.try_into().ok()?) as usize;
+            let raw = take(bytes, &mut pos, len)?;
+            source_meter_ids.push(String::from_utf8(raw).ok()?);
+        }
+        let total_scaled_amount = u128::from_le_bytes(take(bytes, &mut pos, 16)?.try_into().ok()?);
+        let ledger_seq = u64::from_le_bytes(take(bytes, &mut pos, 8)?.try_into().ok()?);
+        let ledger_hash = take(bytes, &mut pos, 32)?.try_into().ok()?;
+        let ledger_close_time = u64::from_le_bytes(take(bytes, &mut pos, 8)?.try_into().ok()?);
+        let tx_envelope_hash = take(bytes, &mut pos, 32)?.try_into().ok()?;
+        let state_commitment = take(bytes, &mut pos, 32)?.try_into().ok()?;
+        Some(Self {
+            batch_id,
+            source_meter_ids,
+            total_scaled_amount,
+            ledger_seq,
+            ledger_hash,
+            ledger_close_time,
+            tx_envelope_hash,
+            state_commitment,
+        })
+    }
+}
+
+/// A detected reorg and the batches it affects.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LedgerReorg {
+    /// First ledger sequence where the local chain diverges from canonical.
+    pub divergence_seq: u64,
+    /// Number of ledgers from the divergence point to the local tip.
+    pub depth: usize,
+    /// Batch ids settled at or after `divergence_seq`.
+    pub affected_batches: Vec<u64>,
+    /// Whether the depth exceeds the auto-recovery limit (operator action).
+    pub requires_manual: bool,
+}
+
+/// Result of a completed recovery.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RecoveryOutcome {
+    pub epoch: u64,
+    pub rolled_back: usize,
+    pub replayed: usize,
+}
+
+/// Tunables for reorg handling (issue #41 bounds).
+#[derive(Clone, Copy, Debug)]
+pub struct ReorgConfig {
+    pub poll_interval: Duration,
+    /// How many recent batches/ledgers to compare against canonical.
+    pub compare_window: usize,
+    /// Consecutive diverging ledgers required to declare a reorg.
+    pub depth_threshold: usize,
+    /// Maximum depth recoverable automatically; deeper escalates to an operator.
+    pub max_auto_depth: usize,
+    /// Count-based retention for the reorg log.
+    pub retention_batches: usize,
+    /// Age-based retention (seconds).
+    pub retention_secs: u64,
+    /// Max settlements buffered while a recovery is in progress.
+    pub queue_capacity: usize,
+}
+
+impl Default for ReorgConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(30),
+            compare_window: 100,
+            depth_threshold: 2,
+            max_auto_depth: 10,
+            retention_batches: 1000,
+            retention_secs: 24 * 60 * 60,
+            queue_capacity: 10_000,
+        }
+    }
+}
+
+/// Canonical-chain queries against a trusted archival node.
+#[async_trait]
+pub trait LedgerOracle: Send + Sync {
+    /// Canonical `(seq, hash)` for the inclusive range `[start, end]`.
+    async fn get_ledger_range(&self, start: u64, end: u64) -> Result<Vec<LedgerInfo>, String>;
+
+    /// Whether `tx_hash` is included in the canonical ledger `ledger_seq`.
+    async fn is_tx_in_ledger(&self, tx_hash: [u8; 32], ledger_seq: u64) -> Result<bool, String>;
+}
+
+/// Contract operations used during recovery.
+#[async_trait]
+pub trait ReorgContract: Send + Sync {
+    /// Roll back `batch_id` on the contract with the given reason code.
+    async fn rollback_batch(&self, batch_id: u64, reason: u32) -> Result<(), String>;
+
+    /// Re-submit `batch_id` under a fresh `nonce`. The contract must reject
+    /// duplicate nonces.
+    async fn submit_replay(
+        &self,
+        batch_id: u64,
+        nonce: u64,
+        meter_ids: &[String],
+    ) -> Result<(), String>;
+}
+
+/// Orchestrates reorg detection and recovery over a [`ReorgLog`].
+pub struct ReorgHandler {
+    oracle: Arc<dyn LedgerOracle>,
+    contract: Arc<dyn ReorgContract>,
+    log: Arc<ReorgLog>,
+    config: ReorgConfig,
+    reorg_epoch: AtomicU64,
+    reorg_in_progress: AtomicBool,
+    queue: Mutex<VecDeque<BatchState>>,
+    used_nonces: Mutex<HashSet<u64>>,
+}
+
+impl ReorgHandler {
+    /// Build a handler over the given oracle, contract, and log.
+    pub fn new(
+        oracle: Arc<dyn LedgerOracle>,
+        contract: Arc<dyn ReorgContract>,
+        log: Arc<ReorgLog>,
+        config: ReorgConfig,
+    ) -> Self {
+        Self {
+            oracle,
+            contract,
+            log,
+            config,
+            reorg_epoch: AtomicU64::new(0),
+            reorg_in_progress: AtomicBool::new(false),
+            queue: Mutex::new(VecDeque::new()),
+            used_nonces: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// The shared reorg log.
+    pub fn log(&self) -> &Arc<ReorgLog> {
+        &self.log
+    }
+
+    /// Whether a recovery is currently in progress.
+    pub fn is_recovering(&self) -> bool {
+        self.reorg_in_progress.load(Ordering::Acquire)
+    }
+
+    /// Number of settlements buffered awaiting recovery completion.
+    pub fn queued_len(&self) -> usize {
+        self.queue.lock().len()
+    }
+
+    /// Current reorg epoch (incremented once per recovery).
+    pub fn epoch(&self) -> u64 {
+        self.reorg_epoch.load(Ordering::Acquire)
+    }
+
+    /// Record a freshly settled batch. While a recovery is in progress the batch
+    /// is buffered (up to the queue capacity) instead of being logged. Returns
+    /// `Ok(true)` if it was queued, `Ok(false)` if it was logged.
+    pub fn record_settled_batch(&self, batch: BatchState) -> Result<bool, String> {
+        if self.reorg_in_progress.load(Ordering::Acquire) {
+            let mut q = self.queue.lock();
+            if q.len() >= self.config.queue_capacity {
+                return Err("recovery queue is full".to_string());
+            }
+            q.push_back(batch);
+            Ok(true)
+        } else {
+            self.log.put(batch);
+            Ok(false)
+        }
+    }
+
+    /// Nonce for replaying `batch_id` in `epoch`: unique per (epoch, batch_id).
+    fn replay_nonce(epoch: u64, batch_id: u64) -> u64 {
+        (epoch << 32) | (batch_id & 0xFFFF_FFFF)
+    }
+
+    /// Compare the most-recent cached ledgers against canonical and report a
+    /// reorg if at least `depth_threshold` consecutive ledgers diverge.
+    pub async fn detect_reorg(&self) -> Result<Option<LedgerReorg>, String> {
+        let cached = self.log.recent(self.config.compare_window);
+        if cached.is_empty() {
+            return Ok(None);
+        }
+        let min_seq = cached.iter().map(|b| b.ledger_seq).min().unwrap_or(0);
+        let max_seq = cached.iter().map(|b| b.ledger_seq).max().unwrap_or(0);
+        let canonical = self.oracle.get_ledger_range(min_seq, max_seq).await?;
+
+        let mut canon = std::collections::HashMap::new();
+        for l in canonical {
+            canon.insert(l.seq, l.hash);
+        }
+
+        // Cached hash per ledger sequence, ascending.
+        let mut cached_hash = std::collections::BTreeMap::new();
+        for b in &cached {
+            cached_hash.insert(b.ledger_seq, b.ledger_hash);
+        }
+
+        let mut run_start: Option<u64> = None;
+        let mut run_len = 0usize;
+        let mut found = None;
+        for (&seq, &chash) in &cached_hash {
+            let diverges = canon.get(&seq).is_some_and(|c| *c != chash);
+            if diverges {
+                if run_start.is_none() {
+                    run_start = Some(seq);
+                    run_len = 0;
+                }
+                run_len += 1;
+                if run_len >= self.config.depth_threshold {
+                    found = run_start;
+                    break;
+                }
+            } else {
+                run_start = None;
+                run_len = 0;
+            }
+        }
+
+        let Some(divergence_seq) = found else {
+            return Ok(None);
+        };
+        let depth = (max_seq - divergence_seq + 1) as usize;
+        let mut affected_batches: Vec<u64> = cached
+            .iter()
+            .filter(|b| b.ledger_seq >= divergence_seq)
+            .map(|b| b.batch_id)
+            .collect();
+        affected_batches.sort_unstable();
+        Ok(Some(LedgerReorg {
+            divergence_seq,
+            depth,
+            affected_batches,
+            requires_manual: depth > self.config.max_auto_depth,
+        }))
+    }
+
+    /// Roll back and replay all batches affected by `reorg`. Errors (without
+    /// mutating state) when the reorg requires manual intervention.
+    pub async fn recover(&self, reorg: &LedgerReorg) -> Result<RecoveryOutcome, String> {
+        if reorg.requires_manual {
+            return Err(format!(
+                "reorg depth {} exceeds auto-recovery limit {}; operator action required",
+                reorg.depth, self.config.max_auto_depth
+            ));
+        }
+
+        self.reorg_in_progress.store(true, Ordering::Release);
+        let epoch = self.reorg_epoch.fetch_add(1, Ordering::AcqRel) + 1;
+
+        let affected = self.log.batches_from_seq(reorg.divergence_seq);
+
+        let mut rolled_back = 0;
+        for batch in &affected {
+            self.contract
+                .rollback_batch(batch.batch_id, REORG_ROLLBACK)
+                .await?;
+            self.log.remove(batch.ledger_seq, batch.tx_envelope_hash);
+            rolled_back += 1;
+        }
+
+        let mut replayed = 0;
+        for batch in &affected {
+            let nonce = Self::replay_nonce(epoch, batch.batch_id);
+            if !self.used_nonces.lock().insert(nonce) {
+                self.reorg_in_progress.store(false, Ordering::Release);
+                return Err(format!("replay nonce {nonce} already used"));
+            }
+            self.contract
+                .submit_replay(batch.batch_id, nonce, &batch.source_meter_ids)
+                .await?;
+            replayed += 1;
+        }
+
+        // Flush settlements buffered during recovery.
+        let queued: Vec<BatchState> = self.queue.lock().drain(..).collect();
+        for batch in queued {
+            self.log.put(batch);
+        }
+        self.reorg_in_progress.store(false, Ordering::Release);
+
+        Ok(RecoveryOutcome {
+            epoch,
+            rolled_back,
+            replayed,
+        })
+    }
+
+    /// Prune reorg-log entries older than the configured age relative to `now`
+    /// (Unix seconds). Count-based retention is enforced continuously on insert.
+    pub fn prune(&self, now: u64) -> usize {
+        self.log.prune_older_than(now, self.config.retention_secs)
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! * [`durable_queue`] — disk-backed spillover queue for the cross-shard
 //!   credit-flow protocol.
+//! * [`reorg_log`] — settled-batch state log for Soroban reorg rollback/replay.
 //! * [`timescaledb`] — workload-priority-partitioned connection pooling.
 
 pub mod durable_queue;
 pub mod reorg_log;
+pub mod timescaledb;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,3 +4,4 @@
 //! credit-flow protocol (see [`durable_queue`]).
 
 pub mod durable_queue;
+pub mod reorg_log;

--- a/src/storage/reorg_log.rs
+++ b/src/storage/reorg_log.rs
@@ -1,0 +1,114 @@
+//! Reorg log: durable record of settled batch state for rollback/replay (#41).
+//!
+//! The blueprint specifies a RocksDB column family keyed by `ledger_seq` with
+//! prefix seeks. To keep the release build free of a `librocksdb-sys` C++
+//! toolchain (which `rust:slim` does not carry), this is a portable, ordered
+//! in-memory store with the same access shape: a `BTreeMap` keyed by
+//! `(ledger_seq, tx_envelope_hash)` gives ordered prefix seeks by ledger
+//! sequence, and an insertion-order ring enforces the count-based retention
+//! window. A RocksDB backend can replace this behind the same API later.
+
+use std::collections::{BTreeMap, VecDeque};
+
+use parking_lot::Mutex;
+
+use crate::blockchain::soroban::reorg_handler::BatchState;
+
+type Key = (u64, [u8; 32]);
+
+struct LogInner {
+    entries: BTreeMap<Key, BatchState>,
+    order: VecDeque<Key>,
+}
+
+/// Ordered, bounded log of settled batch state.
+pub struct ReorgLog {
+    inner: Mutex<LogInner>,
+    retention_batches: usize,
+}
+
+impl ReorgLog {
+    /// Create a log retaining at most `retention_batches` most-recent entries.
+    pub fn new(retention_batches: usize) -> Self {
+        Self {
+            inner: Mutex::new(LogInner {
+                entries: BTreeMap::new(),
+                order: VecDeque::new(),
+            }),
+            retention_batches,
+        }
+    }
+
+    /// Record (or overwrite) a settled batch, evicting the oldest entries beyond
+    /// the retention window.
+    pub fn put(&self, batch: BatchState) {
+        let key = (batch.ledger_seq, batch.tx_envelope_hash);
+        let mut g = self.inner.lock();
+        if g.entries.insert(key, batch).is_none() {
+            g.order.push_back(key);
+        }
+        while g.order.len() > self.retention_batches {
+            if let Some(old) = g.order.pop_front() {
+                g.entries.remove(&old);
+            }
+        }
+    }
+
+    /// All batches with `ledger_seq >= seq`, ascending (prefix seek).
+    pub fn batches_from_seq(&self, seq: u64) -> Vec<BatchState> {
+        let g = self.inner.lock();
+        g.entries
+            .range((seq, [0u8; 32])..)
+            .map(|(_, v)| v.clone())
+            .collect()
+    }
+
+    /// The `n` most recently recorded batches, newest first.
+    pub fn recent(&self, n: usize) -> Vec<BatchState> {
+        let g = self.inner.lock();
+        g.order
+            .iter()
+            .rev()
+            .take(n)
+            .filter_map(|k| g.entries.get(k).cloned())
+            .collect()
+    }
+
+    /// Remove a single batch by its key, returning it if present.
+    pub fn remove(&self, ledger_seq: u64, tx_envelope_hash: [u8; 32]) -> Option<BatchState> {
+        let key = (ledger_seq, tx_envelope_hash);
+        let mut g = self.inner.lock();
+        let removed = g.entries.remove(&key);
+        if removed.is_some() {
+            g.order.retain(|k| *k != key);
+        }
+        removed
+    }
+
+    /// Drop entries whose `ledger_close_time` is older than `max_age` relative to
+    /// `now` (both Unix seconds). Returns the number pruned.
+    pub fn prune_older_than(&self, now: u64, max_age: u64) -> usize {
+        let mut g = self.inner.lock();
+        let stale: Vec<Key> = g
+            .entries
+            .iter()
+            .filter(|(_, v)| now.saturating_sub(v.ledger_close_time) > max_age)
+            .map(|(k, _)| *k)
+            .collect();
+        for k in &stale {
+            g.entries.remove(k);
+        }
+        g.order.retain(|k| !stale.contains(k));
+        stale.len()
+    }
+
+    /// Number of retained batches.
+    pub fn len(&self) -> usize {
+        self.inner.lock().entries.len()
+    }
+
+    /// Whether the log is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().entries.is_empty()
+    }
+}

--- a/tests/blockchain/mod.rs
+++ b/tests/blockchain/mod.rs
@@ -1,0 +1,1 @@
+pub mod reorg_recovery_test;

--- a/tests/blockchain/reorg_recovery_test.rs
+++ b/tests/blockchain/reorg_recovery_test.rs
@@ -1,0 +1,281 @@
+//! Tests for Soroban reorg detection and recovery (issue #41).
+//!
+//! Chain access is mocked, so these run without a Soroban devnet while still
+//! exercising divergence detection, rollback, replay-nonce protection, recovery
+//! gating, depth-limit escalation, and reorg-log retention.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+
+use utility_backend::blockchain::soroban::reorg_handler::{
+    BatchState, LedgerInfo, LedgerOracle, ReorgConfig, ReorgContract, ReorgHandler,
+};
+use utility_backend::storage::reorg_log::ReorgLog;
+
+struct MockOracle {
+    canonical: Vec<LedgerInfo>,
+}
+
+#[async_trait]
+impl LedgerOracle for MockOracle {
+    async fn get_ledger_range(&self, start: u64, end: u64) -> Result<Vec<LedgerInfo>, String> {
+        Ok(self
+            .canonical
+            .iter()
+            .copied()
+            .filter(|l| l.seq >= start && l.seq <= end)
+            .collect())
+    }
+
+    async fn is_tx_in_ledger(&self, _tx: [u8; 32], _seq: u64) -> Result<bool, String> {
+        Ok(true)
+    }
+}
+
+#[derive(Default)]
+struct MockContract {
+    rollbacks: Mutex<Vec<u64>>,
+    replays: Mutex<Vec<(u64, u64)>>,
+    /// When set, rollback blocks on this lock (to simulate an in-flight recovery).
+    gate: Option<Arc<tokio::sync::Mutex<()>>>,
+}
+
+#[async_trait]
+impl ReorgContract for MockContract {
+    async fn rollback_batch(&self, batch_id: u64, _reason: u32) -> Result<(), String> {
+        if let Some(gate) = &self.gate {
+            gate.lock().await;
+        }
+        self.rollbacks.lock().push(batch_id);
+        Ok(())
+    }
+
+    async fn submit_replay(
+        &self,
+        batch_id: u64,
+        nonce: u64,
+        _meter_ids: &[String],
+    ) -> Result<(), String> {
+        let mut replays = self.replays.lock();
+        if replays.iter().any(|(_, n)| *n == nonce) {
+            return Err("contract rejected duplicate nonce".to_string());
+        }
+        replays.push((batch_id, nonce));
+        Ok(())
+    }
+}
+
+fn hsh(b: u8) -> [u8; 32] {
+    [b; 32]
+}
+
+fn batch(id: u64, seq: u64, hash: [u8; 32], close_time: u64) -> BatchState {
+    let mut tx = [0u8; 32];
+    tx[0] = id as u8;
+    tx[1..9].copy_from_slice(&seq.to_le_bytes());
+    BatchState {
+        batch_id: id,
+        source_meter_ids: vec![format!("MTR-{id}")],
+        total_scaled_amount: u128::from(id) * 1000,
+        ledger_seq: seq,
+        ledger_hash: hash,
+        ledger_close_time: close_time,
+        tx_envelope_hash: tx,
+        state_commitment: [id as u8; 32],
+    }
+}
+
+fn canonical(seqs: std::ops::RangeInclusive<u64>) -> Vec<LedgerInfo> {
+    seqs.map(|s| LedgerInfo {
+        seq: s,
+        hash: hsh(s as u8),
+    })
+    .collect()
+}
+
+fn handler_with(
+    canon: Vec<LedgerInfo>,
+    retention: usize,
+    contract: Arc<MockContract>,
+) -> (Arc<ReorgHandler>, Arc<ReorgLog>) {
+    let oracle: Arc<dyn LedgerOracle> = Arc::new(MockOracle { canonical: canon });
+    let log = Arc::new(ReorgLog::new(retention));
+    let handler = Arc::new(ReorgHandler::new(
+        oracle,
+        contract as Arc<dyn ReorgContract>,
+        log.clone(),
+        ReorgConfig::default(),
+    ));
+    (handler, log)
+}
+
+#[test]
+fn test_batch_state_codec_roundtrip() {
+    let b = batch(7, 42, hsh(9), 1700);
+    let bytes = b.to_bytes();
+    assert_eq!(BatchState::from_bytes(&bytes).as_ref(), Some(&b));
+    assert!(BatchState::from_bytes(&bytes[..bytes.len() - 1]).is_none());
+}
+
+#[tokio::test]
+async fn test_detect_and_recover_reorg() {
+    let contract = Arc::new(MockContract::default());
+    let (handler, log) = handler_with(canonical(1..=10), 1000, contract.clone());
+
+    // Local chain matches canonical below seq 6 and diverges from 6 onward.
+    for s in 1..=10u64 {
+        let local_hash = if s < 6 {
+            hsh(s as u8)
+        } else {
+            hsh(100 + s as u8)
+        };
+        handler
+            .record_settled_batch(batch(s, s, local_hash, 1000))
+            .unwrap();
+    }
+    assert_eq!(log.len(), 10);
+
+    let reorg = handler
+        .detect_reorg()
+        .await
+        .unwrap()
+        .expect("reorg should be detected");
+    assert_eq!(reorg.divergence_seq, 6);
+    assert_eq!(reorg.depth, 5);
+    assert_eq!(reorg.affected_batches, vec![6, 7, 8, 9, 10]);
+    assert!(!reorg.requires_manual);
+
+    let outcome = handler.recover(&reorg).await.unwrap();
+    assert_eq!(outcome.rolled_back, 5);
+    assert_eq!(outcome.replayed, 5);
+    assert_eq!(outcome.epoch, 1);
+
+    assert_eq!(*contract.rollbacks.lock(), vec![6, 7, 8, 9, 10]);
+
+    let replays = contract.replays.lock().clone();
+    assert_eq!(replays.len(), 5);
+    let nonces: HashSet<u64> = replays.iter().map(|(_, n)| *n).collect();
+    assert_eq!(nonces.len(), 5, "replay nonces must be unique");
+
+    assert!(
+        log.batches_from_seq(6).is_empty(),
+        "rolled-back batches gone"
+    );
+    assert!(!handler.is_recovering());
+}
+
+#[tokio::test]
+async fn test_deep_reorg_requires_manual_intervention() {
+    let contract = Arc::new(MockContract::default());
+    let (handler, _log) = handler_with(canonical(1..=20), 1000, contract.clone());
+
+    // Diverge from seq 5 -> depth 16 > auto limit 10.
+    for s in 1..=20u64 {
+        let local_hash = if s < 5 {
+            hsh(s as u8)
+        } else {
+            hsh(100 + s as u8)
+        };
+        handler
+            .record_settled_batch(batch(s, s, local_hash, 1000))
+            .unwrap();
+    }
+
+    let reorg = handler.detect_reorg().await.unwrap().expect("reorg");
+    assert_eq!(reorg.divergence_seq, 5);
+    assert!(reorg.requires_manual);
+
+    let err = handler.recover(&reorg).await.unwrap_err();
+    assert!(err.contains("operator action"), "got: {err}");
+    assert!(contract.rollbacks.lock().is_empty(), "no auto rollback");
+}
+
+#[tokio::test]
+async fn test_settlements_queued_during_recovery() {
+    let gate = Arc::new(tokio::sync::Mutex::new(()));
+    let contract = Arc::new(MockContract {
+        gate: Some(gate.clone()),
+        ..Default::default()
+    });
+    let (handler, log) = handler_with(canonical(1..=4), 1000, contract);
+
+    for s in 1..=4u64 {
+        let local_hash = if s < 3 {
+            hsh(s as u8)
+        } else {
+            hsh(50 + s as u8)
+        };
+        handler
+            .record_settled_batch(batch(s, s, local_hash, 1000))
+            .unwrap();
+    }
+    let reorg = handler.detect_reorg().await.unwrap().expect("reorg");
+    assert_eq!(reorg.affected_batches, vec![3, 4]);
+
+    // Hold the gate so the first rollback blocks inside recover().
+    let guard = gate.lock().await;
+    let task = {
+        let handler = handler.clone();
+        tokio::spawn(async move { handler.recover(&reorg).await })
+    };
+
+    for _ in 0..10_000 {
+        if handler.is_recovering() {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert!(handler.is_recovering());
+
+    // A settlement arriving mid-recovery must be buffered, not logged.
+    let queued = handler
+        .record_settled_batch(batch(99, 99, hsh(7), 1000))
+        .unwrap();
+    assert!(queued, "settlement should be queued during recovery");
+    assert_eq!(handler.queued_len(), 1);
+    assert!(log.batches_from_seq(99).is_empty(), "not logged yet");
+
+    drop(guard);
+    let outcome = task.await.unwrap().unwrap();
+    assert_eq!(outcome.rolled_back, 2);
+
+    // Queue flushed into the log once recovery completed.
+    assert_eq!(handler.queued_len(), 0);
+    assert_eq!(log.batches_from_seq(99).len(), 1);
+}
+
+#[test]
+fn test_count_retention_window() {
+    let contract = Arc::new(MockContract::default());
+    let (handler, log) = handler_with(Vec::new(), 1000, contract);
+
+    for i in 0..1200u64 {
+        handler
+            .record_settled_batch(batch(i, i, hsh((i % 250) as u8), 1000))
+            .unwrap();
+    }
+    assert_eq!(log.len(), 1000, "only the last 1000 batches are retained");
+    assert!(log.batches_from_seq(0).iter().all(|b| b.ledger_seq >= 200));
+}
+
+#[test]
+fn test_age_based_pruning() {
+    let contract = Arc::new(MockContract::default());
+    let (handler, log) = handler_with(Vec::new(), 1000, contract);
+
+    handler
+        .record_settled_batch(batch(1, 1, hsh(1), 0))
+        .unwrap(); // very old
+    handler
+        .record_settled_batch(batch(2, 2, hsh(2), 190_000))
+        .unwrap(); // recent
+
+    // now = 200_000, retention = 24h (86_400s): batch 1 is stale, batch 2 is not.
+    let pruned = handler.prune(200_000);
+    assert_eq!(pruned, 1);
+    assert_eq!(log.len(), 1);
+    assert_eq!(log.batches_from_seq(0)[0].batch_id, 2);
+}

--- a/tests/blockchain/reorg_recovery_test.rs
+++ b/tests/blockchain/reorg_recovery_test.rs
@@ -47,7 +47,9 @@ struct MockContract {
 impl ReorgContract for MockContract {
     async fn rollback_batch(&self, batch_id: u64, _reason: u32) -> Result<(), String> {
         if let Some(gate) = &self.gate {
-            gate.lock().await;
+            // Block until the test releases the gate, simulating in-flight work.
+            // Named binding (not `_`) so it isn't flagged as an unused guard.
+            let _held = gate.lock().await;
         }
         self.rollbacks.lock().push(batch_id);
         Ok(())

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod api_tests;
+pub mod blockchain;
 pub mod gateway_tests;
 pub mod settlement;
 pub mod soroban_tests;


### PR DESCRIPTION
# Soroban Contract State Synchronization After Blockchain Reorg with Replay Protection (#41)

Closes #41

## What's added

| Module | Responsibility |
|---|---|
| `blockchain/soroban/reorg_handler.rs` | `ReorgHandler` — `detect_reorg()` compares the recent cached chain against canonical and flags a reorg when **≥ 2 consecutive ledgers diverge**; `recover()` rolls back affected batches (`rollback_batch`, reason `REORG_ROLLBACK = 1`) and replays each under a **fresh per-epoch nonce** (the contract rejects duplicate nonces). Depth **> 10** escalates to manual intervention. A `reorg_in_progress` flag **buffers** new settlements in a bounded (10k) queue during recovery, flushed afterward. `BatchState` carries a compact binary codec (protobuf stand-in). |
| `blockchain/soroban/client.rs` | Adds `get_ledger_range(start, end) -> Vec<LedgerInfo>` and `is_tx_in_ledger(tx_hash, seq) -> bool` JSON-RPC methods. |
| `storage/reorg_log.rs` | Ordered, bounded reorg log: `BTreeMap` keyed by `(ledger_seq, tx_envelope_hash)` for **prefix seeks by ledger sequence**, with **count-based (last 1000)** and **age-based (24h)** retention. |
