### PR TITLE
Add async cancellation safety and graceful shutdown protocol (#49)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod blockchain;
 pub mod gateway;
 pub mod ingestion;
 pub mod lifecycle;
+pub mod memory;
 pub mod settlement;
 pub mod soroban;
 pub mod storage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod blockchain;
 pub mod gateway;
 pub mod ingestion;
+pub mod lifecycle;
 pub mod settlement;
 pub mod soroban;
 pub mod storage;

--- a/src/lifecycle/mod.rs
+++ b/src/lifecycle/mod.rs
@@ -1,0 +1,7 @@
+//! Process lifecycle: structured-concurrency shutdown protocol (issue #49).
+//!
+//! * [`task_group`] — hierarchical cancellation tokens and per-stage task groups.
+//! * [`shutdown`] — ordered, deadline-bounded graceful shutdown with checkpointing.
+
+pub mod shutdown;
+pub mod task_group;

--- a/src/lifecycle/shutdown.rs
+++ b/src/lifecycle/shutdown.rs
@@ -1,0 +1,290 @@
+//! Graceful shutdown protocol with strict phase ordering (issue #49).
+//!
+//! On SIGTERM/SIGINT/SIGHUP the pipeline must drain in a precise order so no
+//! telemetry is lost and the watermark is persisted before exit. Each phase owns
+//! a [`StructuredTaskGroup`]; [`ShutdownProtocol::shutdown`] cancels and drains
+//! them in order, persisting a [`ShutdownCheckpoint`] after each so a crash mid
+//! shutdown can resume from the last completed phase.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use parking_lot::RwLock;
+use tracing::{error, info, warn};
+
+use super::task_group::{CancelToken, StructuredTaskGroup};
+use crate::storage::checkpoint::{CheckpointStore, ShutdownCheckpoint};
+
+/// Ordered shutdown phases. Drainable phases run in declaration order; `Complete`
+/// is the terminal marker.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ShutdownPhase {
+    Acceptors = 0,
+    Reassembly = 1,
+    Parsing = 2,
+    Evaluation = 3,
+    Storage = 4,
+    Watermark = 5,
+    Blockchain = 6,
+    Complete = 7,
+}
+
+impl ShutdownPhase {
+    /// The drainable phases, in the order they must be shut down.
+    pub const DRAIN_ORDER: [ShutdownPhase; 7] = [
+        ShutdownPhase::Acceptors,
+        ShutdownPhase::Reassembly,
+        ShutdownPhase::Parsing,
+        ShutdownPhase::Evaluation,
+        ShutdownPhase::Storage,
+        ShutdownPhase::Watermark,
+        ShutdownPhase::Blockchain,
+    ];
+
+    pub fn index(self) -> usize {
+        self as usize
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ShutdownPhase::Acceptors => "acceptors",
+            ShutdownPhase::Reassembly => "reassembly",
+            ShutdownPhase::Parsing => "parsing",
+            ShutdownPhase::Evaluation => "evaluation",
+            ShutdownPhase::Storage => "storage",
+            ShutdownPhase::Watermark => "watermark",
+            ShutdownPhase::Blockchain => "blockchain",
+            ShutdownPhase::Complete => "complete",
+        }
+    }
+}
+
+/// Hard cap on the per-phase deadline (issue #49 bound).
+const MAX_PHASE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Tunables for the shutdown protocol.
+#[derive(Clone, Debug)]
+pub struct ShutdownConfig {
+    /// Deadline for draining each phase (clamped to 300s).
+    pub per_phase_timeout: Duration,
+    /// In-flight event ceiling; exceeding it aborts shutdown immediately.
+    pub max_in_flight: usize,
+    /// Marker file written once shutdown completes.
+    pub marker_path: PathBuf,
+    /// Optional path for the durable checkpoint.
+    pub checkpoint_path: Option<PathBuf>,
+}
+
+impl Default for ShutdownConfig {
+    fn default() -> Self {
+        Self {
+            per_phase_timeout: Duration::from_secs(30),
+            max_in_flight: 1_000_000,
+            marker_path: PathBuf::from("/tmp/utility_shutdown_complete"),
+            checkpoint_path: None,
+        }
+    }
+}
+
+/// Why a shutdown did not complete cleanly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShutdownError {
+    /// One or more phases exceeded their deadline (shutdown still completed; the
+    /// caller should exit non-zero to trigger a supervisor restart).
+    PhaseTimeout(Vec<ShutdownPhase>),
+    /// In-flight events exceeded the configured ceiling; shutdown aborted.
+    InFlightExceeded(usize),
+    /// An I/O error persisting the checkpoint or marker.
+    Io(String),
+}
+
+impl std::fmt::Display for ShutdownError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShutdownError::PhaseTimeout(phases) => {
+                write!(f, "shutdown phases timed out: {phases:?}")
+            }
+            ShutdownError::InFlightExceeded(n) => {
+                write!(f, "in-flight events {n} exceeded shutdown ceiling")
+            }
+            ShutdownError::Io(e) => write!(f, "shutdown io error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ShutdownError {}
+
+fn now_ns() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0)
+}
+
+/// Orchestrates ordered, deadline-bounded shutdown of the pipeline stages.
+pub struct ShutdownProtocol {
+    phase: AtomicU8,
+    config: ShutdownConfig,
+    root: CancelToken,
+    groups: Vec<Arc<StructuredTaskGroup>>,
+    checkpoint: Arc<RwLock<ShutdownCheckpoint>>,
+}
+
+impl ShutdownProtocol {
+    /// Build a protocol with one task group per drainable phase.
+    pub fn new(mut config: ShutdownConfig) -> Self {
+        if config.per_phase_timeout > MAX_PHASE_TIMEOUT {
+            config.per_phase_timeout = MAX_PHASE_TIMEOUT;
+        }
+        let root = CancelToken::new();
+        let groups = ShutdownPhase::DRAIN_ORDER
+            .iter()
+            .map(|_| Arc::new(StructuredTaskGroup::new(root.child())))
+            .collect();
+        Self {
+            phase: AtomicU8::new(ShutdownPhase::Acceptors as u8),
+            config,
+            root,
+            groups,
+            checkpoint: Arc::new(RwLock::new(ShutdownCheckpoint::new())),
+        }
+    }
+
+    /// The task group for `phase` (panics for the terminal `Complete` phase).
+    pub fn group(&self, phase: ShutdownPhase) -> &Arc<StructuredTaskGroup> {
+        &self.groups[phase.index()]
+    }
+
+    /// The root cancellation token (cancels every stage when fired).
+    pub fn root_token(&self) -> &CancelToken {
+        &self.root
+    }
+
+    /// The shared checkpoint (e.g. to record per-source watermarks before exit).
+    pub fn checkpoint(&self) -> &Arc<RwLock<ShutdownCheckpoint>> {
+        &self.checkpoint
+    }
+
+    /// The phase currently being processed.
+    pub fn current_phase(&self) -> ShutdownPhase {
+        match self.phase.load(Ordering::Acquire) {
+            0 => ShutdownPhase::Acceptors,
+            1 => ShutdownPhase::Reassembly,
+            2 => ShutdownPhase::Parsing,
+            3 => ShutdownPhase::Evaluation,
+            4 => ShutdownPhase::Storage,
+            5 => ShutdownPhase::Watermark,
+            6 => ShutdownPhase::Blockchain,
+            _ => ShutdownPhase::Complete,
+        }
+    }
+
+    /// Total in-flight events across all stages.
+    pub fn total_in_flight(&self) -> usize {
+        self.groups.iter().map(|g| g.in_flight()).sum()
+    }
+
+    /// Drain all phases in order. Each phase is cancelled then awaited within the
+    /// per-phase deadline; the checkpoint is persisted after each. Returns:
+    /// * `Ok(())` on a clean drain,
+    /// * `Err(PhaseTimeout)` if some phases timed out (shutdown still completed),
+    /// * `Err(InFlightExceeded)` if the in-flight ceiling was hit (aborted).
+    pub async fn shutdown(&self) -> Result<(), ShutdownError> {
+        let mut timed_out: Vec<ShutdownPhase> = Vec::new();
+
+        for phase in ShutdownPhase::DRAIN_ORDER {
+            self.phase.store(phase as u8, Ordering::Release);
+
+            let total = self.total_in_flight();
+            if total > self.config.max_in_flight {
+                error!(
+                    in_flight = total,
+                    ceiling = self.config.max_in_flight,
+                    "CRIT: in-flight events exceed shutdown ceiling; aborting"
+                );
+                return Err(ShutdownError::InFlightExceeded(total));
+            }
+
+            info!(phase = phase.as_str(), "draining shutdown phase");
+            let remaining = self.groups[phase.index()]
+                .shutdown(self.config.per_phase_timeout)
+                .await;
+
+            {
+                let mut cp = self.checkpoint.write();
+                cp.mark_stage(phase.index() as u8);
+                cp.timestamp_ns = now_ns();
+            }
+            self.persist_checkpoint()?;
+
+            if remaining > 0 {
+                warn!(
+                    phase = phase.as_str(),
+                    remaining, "shutdown phase timed out; proceeding"
+                );
+                timed_out.push(phase);
+            }
+        }
+
+        self.phase
+            .store(ShutdownPhase::Complete as u8, Ordering::Release);
+        self.write_marker()?;
+
+        if timed_out.is_empty() {
+            info!("graceful shutdown complete");
+            Ok(())
+        } else {
+            Err(ShutdownError::PhaseTimeout(timed_out))
+        }
+    }
+
+    fn persist_checkpoint(&self) -> Result<(), ShutdownError> {
+        if let Some(path) = &self.config.checkpoint_path {
+            let snapshot = self.checkpoint.read().clone();
+            CheckpointStore::open(path)
+                .save(&snapshot)
+                .map_err(|e| ShutdownError::Io(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    fn write_marker(&self) -> Result<(), ShutdownError> {
+        std::fs::write(&self.config.marker_path, b"").map_err(|e| ShutdownError::Io(e.to_string()))
+    }
+}
+
+/// Block until a shutdown signal arrives, returning its name.
+///
+/// On Unix this listens for SIGTERM, SIGINT, and SIGHUP; elsewhere it falls back
+/// to Ctrl-C.
+#[cfg(unix)]
+pub async fn wait_for_shutdown_signal() -> &'static str {
+    use tokio::signal::unix::{signal, SignalKind};
+    let mut term = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    let mut interrupt = signal(SignalKind::interrupt()).expect("install SIGINT handler");
+    let mut hangup = signal(SignalKind::hangup()).expect("install SIGHUP handler");
+    tokio::select! {
+        _ = term.recv() => "SIGTERM",
+        _ = interrupt.recv() => "SIGINT",
+        _ = hangup.recv() => "SIGHUP",
+    }
+}
+
+#[cfg(not(unix))]
+pub async fn wait_for_shutdown_signal() -> &'static str {
+    let _ = tokio::signal::ctrl_c().await;
+    "CTRL_C"
+}
+
+/// Spawn a task that fires `token` when a shutdown signal arrives. Wire this in
+/// `main` to initiate [`ShutdownProtocol::shutdown`].
+pub fn spawn_signal_listener(token: CancelToken) {
+    tokio::spawn(async move {
+        let signal = wait_for_shutdown_signal().await;
+        info!(signal, "received shutdown signal");
+        token.cancel();
+    });
+}

--- a/src/lifecycle/task_group.rs
+++ b/src/lifecycle/task_group.rs
@@ -1,0 +1,151 @@
+//! Structured concurrency primitives for graceful shutdown (issue #49).
+//!
+//! The blueprint references `tokio_util`'s `CancellationToken` / `TaskGroup`.
+//! To avoid a new dependency (and an API that does not exist under that exact
+//! name), this provides self-contained equivalents over plain `tokio`:
+//!
+//! * [`CancelToken`] — a hierarchical cancellation signal. Cancelling a parent
+//!   cascades to all of its child tokens, modelling the per-stage token tree.
+//! * [`StructuredTaskGroup`] — owns the tasks of one pipeline stage and its
+//!   cancellation token; [`StructuredTaskGroup::shutdown`] cancels then drains
+//!   them within a deadline, reporting how many failed to finish in time.
+
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+#[derive(Default)]
+struct CancelInner {
+    cancelled: AtomicBool,
+    notify: Notify,
+    children: Mutex<Vec<CancelToken>>,
+}
+
+/// A hierarchical cancellation signal. Cheaply cloneable; clones share state.
+#[derive(Clone, Default)]
+pub struct CancelToken {
+    inner: Arc<CancelInner>,
+}
+
+impl CancelToken {
+    /// Create a new, un-cancelled root token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Request cancellation, waking waiters and cascading to child tokens.
+    pub fn cancel(&self) {
+        if !self.inner.cancelled.swap(true, Ordering::AcqRel) {
+            self.inner.notify.notify_waiters();
+            for child in self.inner.children.lock().iter() {
+                child.cancel();
+            }
+        }
+    }
+
+    /// Resolve once cancellation is requested. A bounded re-poll backstops the
+    /// wait so a `notify_waiters` racing ahead of registration cannot hang it.
+    pub async fn cancelled(&self) {
+        while !self.is_cancelled() {
+            let notified = self.inner.notify.notified();
+            if self.is_cancelled() {
+                return;
+            }
+            let _ = tokio::time::timeout(Duration::from_millis(50), notified).await;
+        }
+    }
+
+    /// Create a child token that is cancelled when this token is (or already is).
+    pub fn child(&self) -> CancelToken {
+        let child = CancelToken::new();
+        if self.is_cancelled() {
+            child.cancel();
+        } else {
+            self.inner.children.lock().push(child.clone());
+        }
+        child
+    }
+}
+
+/// Owns the tasks of one pipeline stage plus its cancellation token.
+pub struct StructuredTaskGroup {
+    token: CancelToken,
+    handles: Mutex<Vec<JoinHandle<()>>>,
+    in_flight: Arc<AtomicUsize>,
+}
+
+impl StructuredTaskGroup {
+    /// Create a group governed by `token`.
+    pub fn new(token: CancelToken) -> Self {
+        Self {
+            token,
+            handles: Mutex::new(Vec::new()),
+            in_flight: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// The group's cancellation token (clone it into spawned tasks to observe
+    /// cancellation).
+    pub fn token(&self) -> &CancelToken {
+        &self.token
+    }
+
+    /// Spawn a task owned by this group; it is counted as in-flight until it
+    /// completes.
+    pub fn spawn<F>(&self, fut: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.in_flight.fetch_add(1, Ordering::AcqRel);
+        let counter = self.in_flight.clone();
+        let handle = tokio::spawn(async move {
+            fut.await;
+            counter.fetch_sub(1, Ordering::AcqRel);
+        });
+        self.handles.lock().push(handle);
+    }
+
+    /// Number of spawned tasks that have not yet completed.
+    pub fn in_flight(&self) -> usize {
+        self.in_flight.load(Ordering::Acquire)
+    }
+
+    /// Number of registered (not-yet-awaited) task handles.
+    pub fn len(&self) -> usize {
+        self.handles.lock().len()
+    }
+
+    /// Whether the group has no registered handles.
+    pub fn is_empty(&self) -> bool {
+        self.handles.lock().is_empty()
+    }
+
+    /// Cancel the group's token and await its tasks, up to `deadline`. Returns
+    /// the number of tasks still running when the deadline elapsed (0 on a clean
+    /// drain). Timed-out tasks are detached, not aborted, per the graceful
+    /// protocol.
+    pub async fn shutdown(&self, deadline: Duration) -> usize {
+        self.token.cancel();
+        let handles: Vec<JoinHandle<()>> = std::mem::take(&mut *self.handles.lock());
+        let waiter = async move {
+            for handle in handles {
+                let _ = handle.await;
+            }
+        };
+        if tokio::time::timeout(deadline, waiter).await.is_err() {
+            self.in_flight.load(Ordering::Acquire)
+        } else {
+            0
+        }
+    }
+}

--- a/src/storage/checkpoint.rs
+++ b/src/storage/checkpoint.rs
@@ -1,0 +1,123 @@
+//! Durable shutdown checkpoint for crash-safe resume (issue #49).
+//!
+//! Records the last persisted per-source watermark and which shutdown stages
+//! have drained, so a restart can resume from the exact point of interruption.
+//! The blueprint stores this in RocksDB under `shutdown_checkpoint_v1` with a
+//! synchronous write; to keep the build free of a `librocksdb-sys` C++ toolchain
+//! this uses a single file written with `File::sync_all` (the durability
+//! equivalent of `WriteOptions::set_sync(true)`).
+
+use std::collections::HashMap;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+/// Identifier of a meter event source.
+pub type MeterSourceId = String;
+
+/// A point-in-time shutdown checkpoint.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ShutdownCheckpoint {
+    /// When the checkpoint was written (Unix nanoseconds).
+    pub timestamp_ns: i64,
+    /// Last persisted offset (watermark) per meter source.
+    pub watermark: HashMap<MeterSourceId, u64>,
+    /// Bitset of shutdown stages that have fully drained (bit N = stage N).
+    pub stages_drained: u8,
+}
+
+impl ShutdownCheckpoint {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark stage `bit` (0..8) as drained.
+    pub fn mark_stage(&mut self, bit: u8) {
+        if bit < 8 {
+            self.stages_drained |= 1 << bit;
+        }
+    }
+
+    /// Whether stage `bit` has drained.
+    pub fn is_stage_drained(&self, bit: u8) -> bool {
+        bit < 8 && ((self.stages_drained >> bit) & 1) == 1
+    }
+
+    /// Record the highest persisted offset for `source`.
+    pub fn set_watermark(&mut self, source: impl Into<MeterSourceId>, offset: u64) {
+        self.watermark.insert(source.into(), offset);
+    }
+
+    /// Serialize to the durable byte form.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&self.timestamp_ns.to_le_bytes());
+        buf.push(self.stages_drained);
+        buf.extend_from_slice(&(self.watermark.len() as u32).to_le_bytes());
+        for (source, offset) in &self.watermark {
+            buf.extend_from_slice(&(source.len() as u32).to_le_bytes());
+            buf.extend_from_slice(source.as_bytes());
+            buf.extend_from_slice(&offset.to_le_bytes());
+        }
+        buf
+    }
+
+    /// Parse a value produced by [`Self::to_bytes`]; `None` on truncation.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        let mut pos = 0usize;
+        let take = |bytes: &[u8], pos: &mut usize, n: usize| -> Option<Vec<u8>> {
+            let slice = bytes.get(*pos..*pos + n)?.to_vec();
+            *pos += n;
+            Some(slice)
+        };
+        let timestamp_ns = i64::from_le_bytes(take(bytes, &mut pos, 8)?.try_into().ok()?);
+        let stages_drained = *take(bytes, &mut pos, 1)?.first()?;
+        let count = u32::from_le_bytes(take(bytes, &mut pos, 4)?.try_into().ok()?) as usize;
+        let mut watermark = HashMap::with_capacity(count);
+        for _ in 0..count {
+            let key_len = u32::from_le_bytes(take(bytes, &mut pos, 4)?.try_into().ok()?) as usize;
+            let key = String::from_utf8(take(bytes, &mut pos, key_len)?).ok()?;
+            let offset = u64::from_le_bytes(take(bytes, &mut pos, 8)?.try_into().ok()?);
+            watermark.insert(key, offset);
+        }
+        Some(Self {
+            timestamp_ns,
+            watermark,
+            stages_drained,
+        })
+    }
+}
+
+/// File-backed durable store for a single [`ShutdownCheckpoint`].
+pub struct CheckpointStore {
+    path: PathBuf,
+}
+
+impl CheckpointStore {
+    /// Open a store backed by the file at `path` (created on first save).
+    pub fn open(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Persist `checkpoint` durably (data flushed to disk via `sync_all`).
+    pub fn save(&self, checkpoint: &ShutdownCheckpoint) -> io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let bytes = checkpoint.to_bytes();
+        let mut file = std::fs::File::create(&self.path)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        Ok(())
+    }
+
+    /// Load the stored checkpoint, or `None` if absent or unreadable.
+    pub fn load(&self) -> io::Result<Option<ShutdownCheckpoint>> {
+        match std::fs::read(&self.path) {
+            Ok(bytes) => Ok(ShutdownCheckpoint::from_bytes(&bytes)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,8 +1,10 @@
 //! Storage backends.
 //!
+//! * [`checkpoint`] — durable shutdown checkpoint for crash-safe resume.
 //! * [`durable_queue`] — disk-backed spillover queue for the cross-shard
 //!   credit-flow protocol.
 //! * [`timescaledb`] — workload-priority-partitioned connection pooling.
 
+pub mod checkpoint;
 pub mod durable_queue;
 pub mod timescaledb;

--- a/tests/lifecycle/graceful_shutdown_test.rs
+++ b/tests/lifecycle/graceful_shutdown_test.rs
@@ -1,0 +1,184 @@
+//! Tests for the graceful shutdown protocol (issue #49).
+//!
+//! These drive the protocol directly (no real signals/devnet) but cover every
+//! invariant: cancellation hierarchy, per-stage draining, ordered phase
+//! shutdown, per-phase timeout handling, the in-flight ceiling, and durable
+//! checkpoint persistence.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+
+use utility_backend::lifecycle::shutdown::{
+    ShutdownConfig, ShutdownError, ShutdownPhase, ShutdownProtocol,
+};
+use utility_backend::lifecycle::task_group::{CancelToken, StructuredTaskGroup};
+use utility_backend::storage::checkpoint::{CheckpointStore, ShutdownCheckpoint};
+
+fn temp_path(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("util_shutdown_{}_{tag}", std::process::id()))
+}
+
+#[tokio::test]
+async fn test_cancel_token_hierarchy() {
+    let root = CancelToken::new();
+    let child = root.child();
+    assert!(!child.is_cancelled());
+
+    root.cancel();
+    assert!(child.is_cancelled());
+    child.cancelled().await; // resolves immediately
+
+    // A child created after cancellation is already cancelled.
+    assert!(root.child().is_cancelled());
+}
+
+#[tokio::test]
+async fn test_task_group_drains_on_cancel() {
+    let group = StructuredTaskGroup::new(CancelToken::new());
+    let done = Arc::new(AtomicUsize::new(0));
+    for _ in 0..5 {
+        let token = group.token().clone();
+        let done = done.clone();
+        group.spawn(async move {
+            token.cancelled().await;
+            done.fetch_add(1, Ordering::SeqCst);
+        });
+    }
+    assert_eq!(group.in_flight(), 5);
+
+    let remaining = group.shutdown(Duration::from_secs(5)).await;
+    assert_eq!(remaining, 0);
+    assert_eq!(done.load(Ordering::SeqCst), 5);
+}
+
+#[tokio::test]
+async fn test_task_group_reports_timeout() {
+    let group = StructuredTaskGroup::new(CancelToken::new());
+    // Ignores cancellation and outlives the deadline.
+    group.spawn(async {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+    });
+    let remaining = group.shutdown(Duration::from_millis(50)).await;
+    assert_eq!(remaining, 1);
+}
+
+#[tokio::test]
+async fn test_shutdown_drains_phases_in_order() {
+    let order = Arc::new(Mutex::new(Vec::new()));
+    let cfg = ShutdownConfig {
+        per_phase_timeout: Duration::from_secs(5),
+        max_in_flight: 1_000_000,
+        marker_path: temp_path("marker"),
+        checkpoint_path: Some(temp_path("cp")),
+    };
+    let proto = ShutdownProtocol::new(cfg.clone());
+
+    for phase in ShutdownPhase::DRAIN_ORDER {
+        let group = proto.group(phase);
+        let token = group.token().clone();
+        let order = order.clone();
+        group.spawn(async move {
+            token.cancelled().await;
+            order.lock().push(phase);
+        });
+    }
+
+    let result = proto.shutdown().await;
+    assert!(result.is_ok(), "expected clean shutdown, got {result:?}");
+    assert_eq!(*order.lock(), ShutdownPhase::DRAIN_ORDER.to_vec());
+    assert!(
+        cfg.marker_path.exists(),
+        "completion marker must be written"
+    );
+
+    let checkpoint = CheckpointStore::open(cfg.checkpoint_path.as_ref().unwrap())
+        .load()
+        .unwrap()
+        .expect("checkpoint persisted");
+    for phase in ShutdownPhase::DRAIN_ORDER {
+        assert!(
+            checkpoint.is_stage_drained(phase.index() as u8),
+            "stage {phase:?} should be marked drained"
+        );
+    }
+
+    let _ = std::fs::remove_file(&cfg.marker_path);
+    let _ = std::fs::remove_file(cfg.checkpoint_path.as_ref().unwrap());
+}
+
+#[tokio::test]
+async fn test_shutdown_reports_phase_timeout_but_completes() {
+    let cfg = ShutdownConfig {
+        per_phase_timeout: Duration::from_millis(80),
+        max_in_flight: 1_000_000,
+        marker_path: temp_path("marker_to"),
+        checkpoint_path: None,
+    };
+    let proto = ShutdownProtocol::new(cfg.clone());
+    // The parsing phase has a task that ignores cancellation.
+    proto.group(ShutdownPhase::Parsing).spawn(async {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+    });
+
+    match proto.shutdown().await {
+        Err(ShutdownError::PhaseTimeout(phases)) => {
+            assert_eq!(phases, vec![ShutdownPhase::Parsing]);
+        }
+        other => panic!("expected PhaseTimeout, got {other:?}"),
+    }
+    // Shutdown still completes and writes the marker after a phase timeout.
+    assert!(cfg.marker_path.exists());
+    let _ = std::fs::remove_file(&cfg.marker_path);
+}
+
+#[tokio::test]
+async fn test_shutdown_aborts_when_in_flight_exceeds_ceiling() {
+    let cfg = ShutdownConfig {
+        per_phase_timeout: Duration::from_millis(100),
+        max_in_flight: 2,
+        marker_path: temp_path("marker_oom"),
+        checkpoint_path: None,
+    };
+    let proto = ShutdownProtocol::new(cfg);
+    // Five never-finishing tasks parked in a later stage exceed the ceiling.
+    let group = proto.group(ShutdownPhase::Blockchain);
+    for _ in 0..5 {
+        group.spawn(async {
+            std::future::pending::<()>().await;
+        });
+    }
+    assert_eq!(proto.total_in_flight(), 5);
+
+    let result = proto.shutdown().await;
+    assert!(matches!(result, Err(ShutdownError::InFlightExceeded(5))));
+}
+
+#[test]
+fn test_checkpoint_codec_and_durable_store() {
+    let mut cp = ShutdownCheckpoint::new();
+    cp.timestamp_ns = 1_700_000_000_000;
+    cp.mark_stage(0);
+    cp.mark_stage(3);
+    cp.set_watermark("meter-a", 100);
+    cp.set_watermark("meter-b", 250);
+
+    assert!(cp.is_stage_drained(0));
+    assert!(cp.is_stage_drained(3));
+    assert!(!cp.is_stage_drained(1));
+
+    let bytes = cp.to_bytes();
+    assert_eq!(ShutdownCheckpoint::from_bytes(&bytes), Some(cp.clone()));
+    assert!(ShutdownCheckpoint::from_bytes(&bytes[..bytes.len() - 1]).is_none());
+
+    let path = temp_path("cpfile");
+    let store = CheckpointStore::open(&path);
+    assert!(store.load().unwrap().is_none(), "absent before first save");
+    store.save(&cp).unwrap();
+    assert_eq!(store.load().unwrap(), Some(cp));
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/tests/lifecycle/mod.rs
+++ b/tests/lifecycle/mod.rs
@@ -1,0 +1,1 @@
+pub mod graceful_shutdown_test;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod api_tests;
 pub mod gateway_tests;
+pub mod lifecycle;
 pub mod settlement;
 pub mod soroban_tests;
 pub mod storage;


### PR DESCRIPTION
# Async I/O Cancellation Safety and Graceful Shutdown Protocol for Telemetry Stream Lifecycle (#49)

Closes #49

## What's added

| Module | Responsibility |
|---|---|
| `lifecycle/task_group.rs` | **Structured concurrency** over plain tokio: `CancelToken` (hierarchical — cancelling a parent cascades to children, modelling the per-stage token tree) and `StructuredTaskGroup` (owns a stage's tasks + its token; `shutdown()` cancels then drains within a deadline, returning how many tasks overran). |
| `lifecycle/shutdown.rs` | `ShutdownProtocol` drains phases in strict order — **Acceptors → Reassembly → Parsing → Evaluation → Storage → Watermark → Blockchain → Complete** — each within a configurable deadline (default 30 s, capped 300 s). Persists a checkpoint after every phase; enforces the **1,000,000 in-flight ceiling** (CRIT log + abort); writes the `/tmp/utility_shutdown_complete` marker. A phase timeout is logged and shutdown **proceeds**, returning `Err(PhaseTimeout)` so `main` can exit non-zero for a supervised restart. Includes the SIGTERM/SIGINT/SIGHUP signal listener. |
| `storage/checkpoint.rs` | Durable `ShutdownCheckpoint` (timestamp, per-source watermark map, drained-stage bitset) with a binary codec, plus a `CheckpointStore` written via `File::sync_all` — the durability equivalent of RocksDB's `WriteOptions::set_sync(true)`. Enables resume-from-last-completed-phase on restart. |