### PR TITLE
Add hierarchical token-bucket scheduler for grid capacity control (#48)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod blockchain;
 pub mod gateway;
 pub mod ingestion;
+pub mod ratelimit;
 pub mod settlement;
 pub mod soroban;
 pub mod storage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod blockchain;
 pub mod gateway;
 pub mod ingestion;
+pub mod memory;
 pub mod ratelimit;
 pub mod settlement;
 pub mod soroban;

--- a/src/ratelimit/htb.rs
+++ b/src/ratelimit/htb.rs
@@ -1,0 +1,268 @@
+//! Hierarchical Token Bucket (HTB) scheduler for grid capacity allocation (#48).
+//!
+//! Models the grid as a tree of rate-limited buckets (root → region →
+//! substation → feeder → meter). A request at a leaf debits tokens from the leaf
+//! **and every ancestor**, so the sum of children can never exceed a parent's
+//! capacity. A node may go negative down to `-burst` (bursting / borrowing);
+//! beyond that the request is rejected and the whole path is rolled back.
+//!
+//! Time is injected explicitly (`*_at(now_ns)`) so behaviour is deterministic
+//! and testable; a production wrapper supplies the wall clock. Token unit: one
+//! token = 1 µWh.
+
+use std::sync::atomic::{AtomicI64, AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+
+use dashmap::{DashMap, DashSet};
+use parking_lot::RwLock;
+
+/// Sentinel stored in [`HtbNode::parent`] for a root node.
+pub const NO_PARENT: u32 = u32::MAX;
+
+/// Defensive cap on parent-chain traversal (the tree is ≤ 5 deep; this guards
+/// against accidental cycles).
+const MAX_PATH: usize = 64;
+
+const NANOS_PER_SEC: i128 = 1_000_000_000;
+const SECONDS_PER_YEAR: f64 = 365.0 * 24.0 * 60.0 * 60.0;
+
+/// Per-node configuration.
+#[derive(Clone, Copy, Debug)]
+pub struct NodeConfig {
+    /// Sustained refill rate in tokens/second.
+    pub rate: u64,
+    /// Bucket capacity / burst allowance in tokens.
+    pub burst: u64,
+    /// Absolute maximum rate (≥ `rate`); headroom for borrowing.
+    pub ceil: u64,
+    /// Parent node id, or `None` for the root.
+    pub parent: Option<u32>,
+}
+
+/// A single bucket in the hierarchy.
+pub struct HtbNode {
+    id: u32,
+    parent: AtomicU32,
+    rate: AtomicU64,
+    ceil: AtomicU64,
+    burst: AtomicU64,
+    tokens: AtomicI64,
+    last_refill_ns: AtomicI64,
+    debt: AtomicI64,
+    children: DashSet<u32>,
+}
+
+impl HtbNode {
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+    pub fn parent(&self) -> Option<u32> {
+        match self.parent.load(Ordering::Acquire) {
+            NO_PARENT => None,
+            p => Some(p),
+        }
+    }
+    pub fn rate(&self) -> u64 {
+        self.rate.load(Ordering::Acquire)
+    }
+    pub fn ceil(&self) -> u64 {
+        self.ceil.load(Ordering::Acquire)
+    }
+    pub fn burst(&self) -> u64 {
+        self.burst.load(Ordering::Acquire)
+    }
+    pub fn tokens(&self) -> i64 {
+        self.tokens.load(Ordering::Acquire)
+    }
+    /// Currently borrowed amount (negative balance), or 0 if in credit.
+    pub fn debt(&self) -> i64 {
+        self.debt.load(Ordering::Acquire)
+    }
+    pub fn child_ids(&self) -> Vec<u32> {
+        self.children.iter().map(|c| *c).collect()
+    }
+
+    /// Live reconfiguration (used by the admin endpoints).
+    pub fn set_rate(&self, rate: u64) {
+        self.rate.store(rate, Ordering::Release);
+    }
+    pub fn set_ceil(&self, ceil: u64) {
+        self.ceil.store(ceil, Ordering::Release);
+    }
+    pub fn set_burst(&self, burst: u64) {
+        self.burst.store(burst, Ordering::Release);
+    }
+}
+
+/// The hierarchical token-bucket tree.
+pub struct HtbTree {
+    nodes: DashMap<u32, Arc<HtbNode>>,
+    root: RwLock<Option<u32>>,
+    interest_per_sec: f64,
+}
+
+impl HtbTree {
+    /// Create an empty tree with the given debt interest rate (annual, e.g. 0.10
+    /// for 10% APR).
+    pub fn new(interest_apr: f64) -> Self {
+        Self {
+            nodes: DashMap::new(),
+            root: RwLock::new(None),
+            interest_per_sec: interest_apr / SECONDS_PER_YEAR,
+        }
+    }
+
+    /// Insert a node, linking it under its parent (or marking it the root).
+    /// `start_ns` seeds the refill clock so the first refill measures from here.
+    pub fn add_node(&self, id: u32, config: NodeConfig, start_ns: i64) {
+        let node = Arc::new(HtbNode {
+            id,
+            parent: AtomicU32::new(config.parent.unwrap_or(NO_PARENT)),
+            rate: AtomicU64::new(config.rate),
+            ceil: AtomicU64::new(config.ceil),
+            burst: AtomicU64::new(config.burst),
+            tokens: AtomicI64::new(config.burst as i64),
+            last_refill_ns: AtomicI64::new(start_ns),
+            debt: AtomicI64::new(0),
+            children: DashSet::new(),
+        });
+        self.nodes.insert(id, node);
+        match config.parent {
+            Some(parent_id) => {
+                if let Some(parent) = self.nodes.get(&parent_id) {
+                    parent.children.insert(id);
+                }
+            }
+            None => *self.root.write() = Some(id),
+        }
+    }
+
+    /// Look up a node by id.
+    pub fn node(&self, id: u32) -> Option<Arc<HtbNode>> {
+        self.nodes.get(&id).map(|n| n.value().clone())
+    }
+
+    /// The root node id, if set.
+    pub fn root(&self) -> Option<u32> {
+        *self.root.read()
+    }
+
+    /// Number of nodes in the tree.
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Whether the tree has no nodes.
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// The leaf→root path of nodes, or `None` if `leaf_id` is unknown or the
+    /// chain exceeds [`MAX_PATH`] (cycle guard).
+    fn path_to_root(&self, leaf_id: u32) -> Option<Vec<Arc<HtbNode>>> {
+        let mut path = Vec::new();
+        let mut cur = leaf_id;
+        loop {
+            let node = self.nodes.get(&cur)?.value().clone();
+            let parent = node.parent.load(Ordering::Acquire);
+            path.push(node);
+            if path.len() > MAX_PATH {
+                return None;
+            }
+            if parent == NO_PARENT {
+                return Some(path);
+            }
+            cur = parent;
+        }
+    }
+
+    /// Refill a single node up to `now_ns`. Claims the refill window atomically
+    /// (only one caller advances the clock) and tops up tokens via a CAS loop so
+    /// concurrent conformance deductions are not lost.
+    fn refill_node(&self, node: &HtbNode, now_ns: i64) {
+        let last = node.last_refill_ns.load(Ordering::Acquire);
+        if now_ns <= last {
+            return;
+        }
+        if node
+            .last_refill_ns
+            .compare_exchange(last, now_ns, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return; // another caller refilled this window
+        }
+
+        let elapsed_ns = (now_ns - last) as i128;
+        let rate = node.rate.load(Ordering::Acquire) as i128;
+        let mut add = (rate * elapsed_ns / NANOS_PER_SEC) as i64;
+
+        // Debt accrues interest while a node is negative, slightly slowing
+        // recovery (10% APR is negligible per tick, so refill still converges).
+        let current = node.tokens.load(Ordering::Acquire);
+        if current < 0 {
+            let elapsed_sec = elapsed_ns as f64 / NANOS_PER_SEC as f64;
+            let interest = ((-current) as f64 * self.interest_per_sec * elapsed_sec) as i64;
+            add -= interest;
+        }
+
+        let burst = node.burst.load(Ordering::Acquire) as i64;
+        let mut cur = node.tokens.load(Ordering::Acquire);
+        loop {
+            let new = (cur + add).min(burst);
+            match node
+                .tokens
+                .compare_exchange_weak(cur, new, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => {
+                    node.debt.store((-new).max(0), Ordering::Release);
+                    return;
+                }
+                Err(actual) => cur = actual,
+            }
+        }
+    }
+
+    /// Refill every node up to `now_ns` (the periodic O(n) tick).
+    pub fn refill_at(&self, now_ns: i64) {
+        for entry in self.nodes.iter() {
+            self.refill_node(entry.value(), now_ns);
+        }
+    }
+
+    /// Check and reserve `requested` tokens for `leaf_id` at `now_ns`.
+    ///
+    /// Lazily refills the leaf→root path, then debits `requested` from every node
+    /// on it. If any node would drop below `-burst` the whole path is rolled back
+    /// and `false` is returned (the request is non-conforming).
+    pub fn conform_at(&self, leaf_id: u32, requested: u64, now_ns: i64) -> bool {
+        let path = match self.path_to_root(leaf_id) {
+            Some(p) => p,
+            None => return false,
+        };
+        for node in &path {
+            self.refill_node(node, now_ns);
+        }
+
+        let req = requested as i64;
+        let mut deducted = 0usize;
+        for node in &path {
+            let after = node.tokens.fetch_sub(req, Ordering::AcqRel) - req;
+            deducted += 1;
+            let floor = -(node.burst.load(Ordering::Acquire) as i64);
+            if after < floor {
+                // Roll back every node debited so far (this one included).
+                for n in &path[..deducted] {
+                    n.tokens.fetch_add(req, Ordering::AcqRel);
+                }
+                return false;
+            }
+        }
+
+        // Record borrowing (negative balance) as debt.
+        for node in &path {
+            let t = node.tokens.load(Ordering::Acquire);
+            node.debt.store((-t).max(0), Ordering::Release);
+        }
+        true
+    }
+}

--- a/src/ratelimit/htb.rs
+++ b/src/ratelimit/htb.rs
@@ -244,14 +244,12 @@ impl HtbTree {
         }
 
         let req = requested as i64;
-        let mut deducted = 0usize;
-        for node in &path {
+        for (i, node) in path.iter().enumerate() {
             let after = node.tokens.fetch_sub(req, Ordering::AcqRel) - req;
-            deducted += 1;
             let floor = -(node.burst.load(Ordering::Acquire) as i64);
             if after < floor {
                 // Roll back every node debited so far (this one included).
-                for n in &path[..deducted] {
+                for n in &path[..=i] {
                     n.tokens.fetch_add(req, Ordering::AcqRel);
                 }
                 return false;

--- a/src/ratelimit/mod.rs
+++ b/src/ratelimit/mod.rs
@@ -1,0 +1,11 @@
+//! Hierarchical token-bucket rate limiting for grid capacity (issue #48).
+//!
+//! * [`htb`] — the [`HtbTree`](htb::HtbTree) bucket hierarchy, refill, and
+//!   conformance/borrowing logic.
+//! * [`topology`] — grid topology definition, validation, and tree construction.
+
+pub mod htb;
+pub mod topology;
+
+pub use htb::{HtbNode, HtbTree, NodeConfig};
+pub use topology::{NodeDef, TopologyDef, TopologyError};

--- a/src/ratelimit/topology.proto
+++ b/src/ratelimit/topology.proto
@@ -1,0 +1,22 @@
+// Canonical schema for HTB grid topology (issue #48).
+//
+// NOTE: documents the wire contract. The Rust implementation in `topology.rs`
+// mirrors these definitions (`NodeDef` / `TopologyDef`) so the build does not
+// require a `protoc`/`prost` toolchain. Keep field numbers in sync if a protobuf
+// backend is introduced.
+
+syntax = "proto3";
+
+package utility.ratelimit.v1;
+
+message Node {
+  uint32 id = 1;
+  optional uint32 parent_id = 2;
+  uint64 rate_tokens_per_s = 3;
+  uint64 burst_tokens = 4;
+  uint64 ceil_tokens_per_s = 5;
+}
+
+message Topology {
+  repeated Node nodes = 1;
+}

--- a/src/ratelimit/topology.rs
+++ b/src/ratelimit/topology.rs
@@ -1,0 +1,183 @@
+//! Grid topology loader for the HTB scheduler (issue #48).
+//!
+//! The canonical schema is [`topology.proto`](./topology.proto). To keep the
+//! build free of a `protoc` toolchain, topologies are described with the Rust
+//! [`TopologyDef`] (mirroring the proto field-for-field) and validated before a
+//! tree is built: unique ids, existing parents, a single root, no cycles, and
+//! the HTB invariant that the sum of a parent's children's rates never exceeds
+//! the parent's `ceil`.
+
+use std::collections::{HashMap, HashSet};
+
+use super::htb::{HtbTree, NodeConfig};
+
+/// One node in a topology definition (mirrors the proto `Node`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NodeDef {
+    pub id: u32,
+    pub parent_id: Option<u32>,
+    pub rate_tokens_per_s: u64,
+    pub burst_tokens: u64,
+    pub ceil_tokens_per_s: u64,
+}
+
+/// A full topology definition.
+#[derive(Clone, Debug, Default)]
+pub struct TopologyDef {
+    pub nodes: Vec<NodeDef>,
+}
+
+/// Reasons a topology is invalid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TopologyError {
+    Empty,
+    DuplicateId(u32),
+    MissingParent { node: u32, parent: u32 },
+    MultipleRoots,
+    NoRoot,
+    Cycle(u32),
+    ChildRatesExceedParentCeil { parent: u32, sum: u64, ceil: u64 },
+}
+
+impl std::fmt::Display for TopologyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TopologyError::Empty => write!(f, "topology is empty"),
+            TopologyError::DuplicateId(id) => write!(f, "duplicate node id {id}"),
+            TopologyError::MissingParent { node, parent } => {
+                write!(f, "node {node} references missing parent {parent}")
+            }
+            TopologyError::MultipleRoots => write!(f, "topology has more than one root"),
+            TopologyError::NoRoot => write!(f, "topology has no root"),
+            TopologyError::Cycle(id) => write!(f, "cycle detected at node {id}"),
+            TopologyError::ChildRatesExceedParentCeil { parent, sum, ceil } => write!(
+                f,
+                "children of {parent} sum to rate {sum} exceeding ceil {ceil}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TopologyError {}
+
+impl TopologyDef {
+    /// Validate the definition without building a tree.
+    pub fn validate(&self) -> Result<(), TopologyError> {
+        if self.nodes.is_empty() {
+            return Err(TopologyError::Empty);
+        }
+
+        let mut ids = HashSet::with_capacity(self.nodes.len());
+        for node in &self.nodes {
+            if !ids.insert(node.id) {
+                return Err(TopologyError::DuplicateId(node.id));
+            }
+        }
+
+        let mut root = None;
+        for node in &self.nodes {
+            match node.parent_id {
+                None => {
+                    if root.is_some() {
+                        return Err(TopologyError::MultipleRoots);
+                    }
+                    root = Some(node.id);
+                }
+                Some(parent) if !ids.contains(&parent) => {
+                    return Err(TopologyError::MissingParent {
+                        node: node.id,
+                        parent,
+                    });
+                }
+                Some(_) => {}
+            }
+        }
+        if root.is_none() {
+            return Err(TopologyError::NoRoot);
+        }
+
+        // No cycles: every parent chain must reach the root within N steps.
+        let parent_of: HashMap<u32, Option<u32>> =
+            self.nodes.iter().map(|n| (n.id, n.parent_id)).collect();
+        for node in &self.nodes {
+            let mut cur = node.id;
+            let mut steps = 0usize;
+            while let Some(Some(parent)) = parent_of.get(&cur).copied() {
+                cur = parent;
+                steps += 1;
+                if steps > self.nodes.len() {
+                    return Err(TopologyError::Cycle(node.id));
+                }
+            }
+        }
+
+        // Sum of children rates must not exceed each parent's ceil.
+        let mut child_rate_sum: HashMap<u32, u64> = HashMap::new();
+        for node in &self.nodes {
+            if let Some(parent) = node.parent_id {
+                let entry = child_rate_sum.entry(parent).or_insert(0);
+                *entry = entry.saturating_add(node.rate_tokens_per_s);
+            }
+        }
+        for node in &self.nodes {
+            if let Some(&sum) = child_rate_sum.get(&node.id) {
+                if sum > node.ceil_tokens_per_s {
+                    return Err(TopologyError::ChildRatesExceedParentCeil {
+                        parent: node.id,
+                        sum,
+                        ceil: node.ceil_tokens_per_s,
+                    });
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate and build an [`HtbTree`]. Nodes are inserted parents-first so
+    /// child links resolve.
+    pub fn build(&self, interest_apr: f64, start_ns: i64) -> Result<HtbTree, TopologyError> {
+        self.validate()?;
+        let tree = HtbTree::new(interest_apr);
+
+        // Insert in depth order (root first) so a parent always exists when its
+        // children are linked.
+        let depth = self.depths();
+        let mut ordered: Vec<&NodeDef> = self.nodes.iter().collect();
+        ordered.sort_by_key(|n| depth.get(&n.id).copied().unwrap_or(0));
+
+        for node in ordered {
+            tree.add_node(
+                node.id,
+                NodeConfig {
+                    rate: node.rate_tokens_per_s,
+                    burst: node.burst_tokens,
+                    ceil: node.ceil_tokens_per_s,
+                    parent: node.parent_id,
+                },
+                start_ns,
+            );
+        }
+        Ok(tree)
+    }
+
+    /// Depth of each node from the root (root = 0). Assumes a validated DAG.
+    fn depths(&self) -> HashMap<u32, usize> {
+        let parent_of: HashMap<u32, Option<u32>> =
+            self.nodes.iter().map(|n| (n.id, n.parent_id)).collect();
+        let mut depths = HashMap::with_capacity(self.nodes.len());
+        for node in &self.nodes {
+            let mut d = 0usize;
+            let mut cur = node.id;
+            while let Some(Some(parent)) = parent_of.get(&cur).copied() {
+                d += 1;
+                cur = parent;
+                if d > self.nodes.len() {
+                    break;
+                }
+            }
+            depths.insert(node.id, d);
+        }
+        depths
+    }
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod api_tests;
 pub mod gateway_tests;
+pub mod ratelimit;
 pub mod settlement;
 pub mod soroban_tests;
 pub mod storage;

--- a/tests/ratelimit/htb_test.rs
+++ b/tests/ratelimit/htb_test.rs
@@ -1,0 +1,186 @@
+//! Tests for the hierarchical token-bucket scheduler (issue #48).
+//!
+//! Covers topology validation, hierarchical debiting, burst/borrowing bounds,
+//! rollback on rejection, refill/debt repayment, plus property-based checks that
+//! no node is ever driven below its burst floor and that a rejected request is a
+//! no-op.
+
+use proptest::prelude::*;
+
+use utility_backend::ratelimit::htb::HtbTree;
+use utility_backend::ratelimit::topology::{NodeDef, TopologyDef, TopologyError};
+
+/// root(1) ─ feeder(2) ─ meter(4), meter(5)
+///        └ feeder(3)
+fn test_topology() -> TopologyDef {
+    TopologyDef {
+        nodes: vec![
+            NodeDef {
+                id: 1,
+                parent_id: None,
+                rate_tokens_per_s: 1000,
+                burst_tokens: 1000,
+                ceil_tokens_per_s: 1000,
+            },
+            NodeDef {
+                id: 2,
+                parent_id: Some(1),
+                rate_tokens_per_s: 600,
+                burst_tokens: 600,
+                ceil_tokens_per_s: 800,
+            },
+            NodeDef {
+                id: 3,
+                parent_id: Some(1),
+                rate_tokens_per_s: 400,
+                burst_tokens: 400,
+                ceil_tokens_per_s: 800,
+            },
+            NodeDef {
+                id: 4,
+                parent_id: Some(2),
+                rate_tokens_per_s: 200,
+                burst_tokens: 200,
+                ceil_tokens_per_s: 300,
+            },
+            NodeDef {
+                id: 5,
+                parent_id: Some(2),
+                rate_tokens_per_s: 200,
+                burst_tokens: 200,
+                ceil_tokens_per_s: 300,
+            },
+        ],
+    }
+}
+
+fn build() -> HtbTree {
+    test_topology().build(0.10, 0).expect("valid topology")
+}
+
+#[test]
+fn test_topology_validation_ok() {
+    assert!(test_topology().validate().is_ok());
+    let tree = build();
+    assert_eq!(tree.len(), 5);
+    assert_eq!(tree.root(), Some(1));
+}
+
+#[test]
+fn test_topology_rejects_invalid() {
+    // Duplicate id.
+    let mut def = test_topology();
+    def.nodes[1].id = 1;
+    assert_eq!(def.validate(), Err(TopologyError::DuplicateId(1)));
+
+    // Missing parent.
+    let mut def = test_topology();
+    def.nodes[3].parent_id = Some(99);
+    assert_eq!(
+        def.validate(),
+        Err(TopologyError::MissingParent {
+            node: 4,
+            parent: 99
+        })
+    );
+
+    // No root.
+    let mut def = test_topology();
+    def.nodes[0].parent_id = Some(2);
+    assert!(matches!(
+        def.validate(),
+        Err(TopologyError::Cycle(_)) | Err(TopologyError::NoRoot)
+    ));
+
+    // Children rates exceed parent ceil: feeder 2 ceil below child sum.
+    let mut def = test_topology();
+    def.nodes[1].ceil_tokens_per_s = 100; // children 4+5 = 400 > 100
+    assert!(matches!(
+        def.validate(),
+        Err(TopologyError::ChildRatesExceedParentCeil { parent: 2, .. })
+    ));
+}
+
+#[test]
+fn test_hierarchical_debit_and_borrow() {
+    let tree = build();
+
+    // Within capacity: debits leaf + ancestors.
+    assert!(tree.conform_at(4, 100, 0));
+    assert_eq!(tree.node(4).unwrap().tokens(), 100);
+    assert_eq!(tree.node(2).unwrap().tokens(), 500);
+    assert_eq!(tree.node(1).unwrap().tokens(), 900);
+
+    // Borrow into burst: leaf goes negative but stays >= -burst.
+    assert!(tree.conform_at(4, 200, 0));
+    assert_eq!(tree.node(4).unwrap().tokens(), -100);
+    assert_eq!(tree.node(4).unwrap().debt(), 100);
+    assert_eq!(tree.node(2).unwrap().tokens(), 300);
+
+    // Exceeds leaf burst floor (-200): rejected and rolled back.
+    assert!(!tree.conform_at(4, 200, 0));
+    assert_eq!(tree.node(4).unwrap().tokens(), -100, "leaf restored");
+    assert_eq!(tree.node(2).unwrap().tokens(), 300, "parent untouched");
+    assert_eq!(tree.node(1).unwrap().tokens(), 700, "root untouched");
+}
+
+#[test]
+fn test_refill_repays_debt() {
+    let tree = build();
+    // Borrow the leaf down to its floor.
+    assert!(tree.conform_at(4, 400, 0)); // 200 -> -200
+    assert_eq!(tree.node(4).unwrap().tokens(), -200);
+    assert_eq!(tree.node(4).unwrap().debt(), 200);
+
+    // One second of refill at 200 tokens/s brings the leaf back to 0, debt clear.
+    tree.refill_at(1_000_000_000);
+    assert_eq!(tree.node(4).unwrap().tokens(), 0);
+    assert_eq!(tree.node(4).unwrap().debt(), 0);
+
+    // A further second refills toward burst (capped at 200).
+    tree.refill_at(2_000_000_000);
+    assert_eq!(tree.node(4).unwrap().tokens(), 200);
+}
+
+#[test]
+fn test_unknown_meter_rejected() {
+    let tree = build();
+    assert!(!tree.conform_at(999, 1, 0));
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// No request sequence ever drives any node below its burst floor.
+    #[test]
+    fn prop_never_below_burst_floor(
+        reqs in prop::collection::vec((4u32..=5u32, 0u64..400u64), 0..40)
+    ) {
+        let tree = build();
+        for (leaf, amount) in reqs {
+            let _ = tree.conform_at(leaf, amount, 0);
+            for id in [1u32, 2, 3, 4, 5] {
+                let node = tree.node(id).unwrap();
+                prop_assert!(
+                    node.tokens() >= -(node.burst() as i64),
+                    "node {id} tokens {} below floor -{}",
+                    node.tokens(),
+                    node.burst()
+                );
+            }
+        }
+    }
+
+    /// A rejected request leaves the leaf→root path unchanged.
+    #[test]
+    fn prop_rejected_request_is_no_op(amount in 0u64..2000u64) {
+        let tree = build();
+        let _ = tree.conform_at(4, 150, 0);
+        let before: Vec<i64> = [1u32, 2, 4].iter().map(|id| tree.node(*id).unwrap().tokens()).collect();
+        let accepted = tree.conform_at(4, amount, 0);
+        let after: Vec<i64> = [1u32, 2, 4].iter().map(|id| tree.node(*id).unwrap().tokens()).collect();
+        if !accepted {
+            prop_assert_eq!(before, after);
+        }
+    }
+}

--- a/tests/ratelimit/mod.rs
+++ b/tests/ratelimit/mod.rs
@@ -1,0 +1,1 @@
+pub mod htb_test;


### PR DESCRIPTION
# Hierarchical Token Bucket Scheduler for Multi-Tier Grid Capacity Allocation and Congestion Control (#48)

Closes #48

## What's added (`src/ratelimit/`)

| Module | Responsibility |
|---|---|
| `htb.rs` | `HtbTree` of `HtbNode`s with atomic `tokens`/`rate`/`ceil`/`burst`/`debt`. `conform_at(leaf, requested, now_ns)` debits the **leaf and every ancestor**; a node may go negative down to `-burst` (bursting/borrowing), and beyond that the request is **rejected with the whole path rolled back** (leaf→root, then reverse). `refill_*` tops up each node (`rate × elapsed`, capped at `burst`) via a **CAS-claimed refill window** so concurrent deductions aren't lost; **debt** (negative balance) accrues interest (default 10% APR) and is repaid from refill, converging to zero. Token unit = 1 µWh. Time is injected (`*_at(now_ns)`) for determinism. |
| `topology.rs` | `TopologyDef` loader + `validate()`: unique ids, existing parents, exactly one root, **cycle detection**, and the HTB invariant that **Σ(children rates) ≤ parent `ceil`**; then `build()`s the tree (parents-first). |

