### PR TITLE
Add zero-copy framed telemetry ingestion with buffer-pool backpressure 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,11 @@ tokio-stream = "0.1"
 lru = "0.12"
 socket2 = { version = "0.5", features = ["all"] }
 libc = "0.2"
+thread_local = "1"
+rocksdb = "0.21"
+tonic = "0.11"
+prost = "0.12"
+prost-types = "0.12"
 ciborium = "0.2"
 criterion = { version = "0.5", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tokio-stream = "0.1"
 lru = "0.12"
 socket2 = { version = "0.5", features = ["all"] }
 libc = "0.2"
+ciborium = "0.2"
 criterion = { version = "0.5", optional = true }
 
 [dev-dependencies]
@@ -72,4 +73,8 @@ path = "tests/integration/double_mint_prevention.rs"
 
 [[bench]]
 name = "merkle_bench"
+harness = false
+
+[[bench]]
+name = "stream_throughput"
 harness = false

--- a/benches/stream_throughput.rs
+++ b/benches/stream_throughput.rs
@@ -1,0 +1,75 @@
+//! Throughput benchmark for telemetry frame ingestion (issue #33).
+//!
+//! Compares the pooled, length-prefixed reader against the previous pattern of
+//! allocating a fresh `Vec<u8>` per frame. Run with `cargo bench --bench
+//! stream_throughput`.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use tokio::io::AsyncReadExt;
+use tokio::runtime::Runtime;
+
+use utility_backend::ingestion::buffer_pool::BufferPool;
+use utility_backend::ingestion::frame_parser::{read_frame, FrameError, TelemetryFrame};
+
+fn encode_frames(n: usize) -> Vec<u8> {
+    let mut out = Vec::new();
+    for i in 0..n {
+        let frame = TelemetryFrame {
+            meter_id: format!("meter-{i}"),
+            timestamp: i as u64,
+            value: i as f64,
+        };
+        let mut payload = Vec::new();
+        ciborium::into_writer(&frame, &mut payload).expect("encode");
+        out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        out.extend_from_slice(&payload);
+    }
+    out
+}
+
+fn bench_ingestion(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let frames = 10_000;
+    let data = encode_frames(frames);
+
+    let pool = BufferPool::with_defaults();
+    c.bench_function("pooled_read_10k_frames", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut reader: &[u8] = &data;
+                loop {
+                    match read_frame(&mut reader, &pool).await {
+                        Ok(frame) => {
+                            black_box(frame.payload());
+                        }
+                        Err(FrameError::Closed) => break,
+                        Err(e) => panic!("unexpected frame error: {e}"),
+                    }
+                }
+            });
+        });
+    });
+
+    c.bench_function("naive_alloc_read_10k_frames", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut reader: &[u8] = &data;
+                loop {
+                    let mut len_buf = [0u8; 4];
+                    match reader.read_exact(&mut len_buf).await {
+                        Ok(_) => {}
+                        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                        Err(e) => panic!("io error: {e}"),
+                    }
+                    let len = u32::from_be_bytes(len_buf) as usize;
+                    let mut buf = vec![0u8; len]; // fresh allocation per frame
+                    reader.read_exact(&mut buf).await.unwrap();
+                    black_box(&buf);
+                }
+            });
+        });
+    });
+}
+
+criterion_group!(benches, bench_ingestion);
+criterion_main!(benches);

--- a/src/ingestion/buffer_pool.rs
+++ b/src/ingestion/buffer_pool.rs
@@ -1,0 +1,144 @@
+//! Semaphore-gated recycling buffer pool for the telemetry hot path (issue #33).
+//!
+//! Reading every frame into a freshly allocated `Vec<u8>` produces ~10k
+//! allocations/second and unbounded memory under load. This pool pre-sizes a
+//! fixed set of `MAX_FRAME_SIZE` buffers and hands them out via a
+//! [`tokio::sync::Semaphore`], so:
+//!
+//! * memory is bounded to `capacity * buf_size` (default 1024 × 64 KB = 64 MB);
+//! * once all buffers are in flight, [`BufferPool::acquire`] awaits — applying
+//!   backpressure to the reader instead of allocating without limit;
+//! * released buffers are recycled, keeping the steady-state allocation rate at
+//!   ~0 (tracked via [`BufferPool::allocation_count`]).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// Maximum frame payload size per the wire protocol (64 KB).
+pub const MAX_FRAME_SIZE: usize = 64 * 1024;
+
+/// Default number of pooled buffers.
+pub const DEFAULT_POOL_CAPACITY: usize = 1024;
+
+struct PoolInner {
+    free: Mutex<Vec<Vec<u8>>>,
+    buf_size: usize,
+    allocations: AtomicU64,
+}
+
+/// A fixed-capacity pool of reusable byte buffers.
+#[derive(Clone)]
+pub struct BufferPool {
+    inner: Arc<PoolInner>,
+    permits: Arc<Semaphore>,
+    capacity: usize,
+}
+
+impl BufferPool {
+    /// Create a pool of `capacity` buffers, each `buf_size` bytes.
+    pub fn new(capacity: usize, buf_size: usize) -> Self {
+        Self {
+            inner: Arc::new(PoolInner {
+                free: Mutex::new(Vec::with_capacity(capacity)),
+                buf_size,
+                allocations: AtomicU64::new(0),
+            }),
+            permits: Arc::new(Semaphore::new(capacity)),
+            capacity,
+        }
+    }
+
+    /// Create a pool with the issue-#33 defaults (1024 × 64 KB).
+    pub fn with_defaults() -> Self {
+        Self::new(DEFAULT_POOL_CAPACITY, MAX_FRAME_SIZE)
+    }
+
+    /// Size of each buffer in bytes.
+    pub fn buf_size(&self) -> usize {
+        self.inner.buf_size
+    }
+
+    /// Total number of buffers the pool can hand out concurrently.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Buffers currently available to acquire without waiting.
+    pub fn available(&self) -> usize {
+        self.permits.available_permits()
+    }
+
+    /// Total fresh buffer allocations performed (reuses do not count). At steady
+    /// state this plateaus near `capacity`.
+    pub fn allocation_count(&self) -> u64 {
+        self.inner.allocations.load(Ordering::Relaxed)
+    }
+
+    fn take_buffer(&self) -> Vec<u8> {
+        if let Some(buf) = self.inner.free.lock().pop() {
+            buf
+        } else {
+            self.inner.allocations.fetch_add(1, Ordering::Relaxed);
+            vec![0u8; self.inner.buf_size]
+        }
+    }
+
+    /// Acquire a buffer, awaiting if all are in flight (backpressure).
+    pub async fn acquire(&self) -> PooledBuffer {
+        let permit = self
+            .permits
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("buffer pool semaphore is never closed");
+        PooledBuffer {
+            buf: Some(self.take_buffer()),
+            inner: self.inner.clone(),
+            _permit: permit,
+        }
+    }
+
+    /// Acquire a buffer without waiting; `None` if none are free.
+    pub fn try_acquire(&self) -> Option<PooledBuffer> {
+        let permit = self.permits.clone().try_acquire_owned().ok()?;
+        Some(PooledBuffer {
+            buf: Some(self.take_buffer()),
+            inner: self.inner.clone(),
+            _permit: permit,
+        })
+    }
+}
+
+/// A buffer checked out from a [`BufferPool`]; returns itself on drop.
+pub struct PooledBuffer {
+    buf: Option<Vec<u8>>,
+    inner: Arc<PoolInner>,
+    /// Held for RAII: releases the pool slot (backpressure) on drop.
+    #[allow(dead_code)]
+    _permit: OwnedSemaphorePermit,
+}
+
+impl PooledBuffer {
+    /// The full buffer as a mutable slice (`buf_size` bytes).
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.buf.as_mut().expect("buffer present until drop")
+    }
+
+    /// The full buffer as a shared slice.
+    pub fn as_slice(&self) -> &[u8] {
+        self.buf.as_ref().expect("buffer present until drop")
+    }
+}
+
+impl Drop for PooledBuffer {
+    fn drop(&mut self) {
+        if let Some(buf) = self.buf.take() {
+            // Buffers keep their `buf_size` length, so they are reusable as-is.
+            self.inner.free.lock().push(buf);
+        }
+        // `_permit` drops here, freeing a slot for a waiting acquirer.
+    }
+}

--- a/src/ingestion/frame_parser.rs
+++ b/src/ingestion/frame_parser.rs
@@ -1,0 +1,110 @@
+//! Length-prefixed binary frame reader with zero-copy CBOR decoding (issue #33).
+//!
+//! Wire format: `[u32 BE length][CBOR payload of `length` bytes]`. We read the
+//! 4-byte prefix with `read_exact`, validate `length <= MAX_FRAME_SIZE`, then
+//! read exactly `length` bytes into a pooled buffer — bounding per-frame memory
+//! and eliminating the delimiter-scanning blow-up of `read_until`. CBOR is
+//! decoded straight from the pooled slice (no intermediate `Vec` per frame).
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use super::buffer_pool::{BufferPool, PooledBuffer};
+
+/// Bytes of the length prefix.
+pub const LENGTH_PREFIX_LEN: usize = 4;
+
+/// Errors from reading a frame.
+#[derive(Debug)]
+pub enum FrameError {
+    /// The stream ended cleanly at a frame boundary.
+    Closed,
+    /// The advertised length exceeds the protocol maximum (possible attack).
+    FrameTooLarge { length: usize, max: usize },
+    /// An underlying I/O error.
+    Io(std::io::Error),
+    /// CBOR payload failed to decode.
+    Decode(String),
+}
+
+impl std::fmt::Display for FrameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FrameError::Closed => write!(f, "stream closed at frame boundary"),
+            FrameError::FrameTooLarge { length, max } => {
+                write!(f, "frame length {length} exceeds maximum {max}")
+            }
+            FrameError::Io(e) => write!(f, "frame io error: {e}"),
+            FrameError::Decode(e) => write!(f, "frame decode error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for FrameError {}
+
+/// A decoded frame: a pooled buffer plus the valid payload length.
+pub struct Frame {
+    buffer: PooledBuffer,
+    length: usize,
+}
+
+impl Frame {
+    /// The frame payload (the first `length` bytes of the pooled buffer).
+    pub fn payload(&self) -> &[u8] {
+        &self.buffer.as_slice()[..self.length]
+    }
+
+    /// Payload length in bytes.
+    pub fn len(&self) -> usize {
+        self.length
+    }
+
+    /// Whether the payload is empty.
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
+    /// Decode the CBOR payload into `T` directly from the pooled slice.
+    pub fn decode<T: DeserializeOwned>(&self) -> Result<T, FrameError> {
+        ciborium::de::from_reader(self.payload()).map_err(|e| FrameError::Decode(e.to_string()))
+    }
+}
+
+/// Read exactly one frame from `reader`, using a pooled buffer.
+///
+/// Validates the length against `pool.buf_size()` before reading the payload, so
+/// a malicious/garbled prefix cannot cause an oversized read.
+pub async fn read_frame<R>(reader: &mut R, pool: &BufferPool) -> Result<Frame, FrameError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut len_buf = [0u8; LENGTH_PREFIX_LEN];
+    match reader.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Err(FrameError::Closed),
+        Err(e) => return Err(FrameError::Io(e)),
+    }
+
+    let length = u32::from_be_bytes(len_buf) as usize;
+    let max = pool.buf_size();
+    if length > max {
+        return Err(FrameError::FrameTooLarge { length, max });
+    }
+
+    let mut buffer = pool.acquire().await;
+    reader
+        .read_exact(&mut buffer.as_mut_slice()[..length])
+        .await
+        .map_err(FrameError::Io)?;
+
+    Ok(Frame { buffer, length })
+}
+
+/// Example telemetry payload schema (CBOR-encoded on the wire).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TelemetryFrame {
+    pub meter_id: String,
+    pub timestamp: u64,
+    pub value: f64,
+}

--- a/src/ingestion/mod.rs
+++ b/src/ingestion/mod.rs
@@ -1,3 +1,6 @@
+pub mod buffer_pool;
 pub mod collector;
 pub mod drift_estimator;
+pub mod frame_parser;
+pub mod stream_handler;
 pub mod tai64n;

--- a/src/ingestion/stream_handler.rs
+++ b/src/ingestion/stream_handler.rs
@@ -17,8 +17,6 @@ use super::frame_parser::{read_frame, Frame, FrameError};
 pub struct StreamStats {
     /// Frames successfully read and dispatched.
     pub frames: u64,
-    /// Frames rejected for exceeding `MAX_FRAME_SIZE`.
-    pub oversized: u64,
 }
 
 /// Read length-prefixed frames from `reader` until EOF, invoking `on_frame` for
@@ -46,7 +44,7 @@ where
             }
             Err(FrameError::Closed) => return Ok(stats),
             Err(FrameError::FrameTooLarge { length, max }) => {
-                stats.oversized += 1;
+                // Framing is unrecoverable after a bogus length; log and end.
                 warn!(
                     length,
                     max, "SECURITY: oversized telemetry frame; dropping connection"

--- a/src/ingestion/stream_handler.rs
+++ b/src/ingestion/stream_handler.rs
@@ -1,0 +1,59 @@
+//! Backpressured telemetry stream handler (issue #33).
+//!
+//! Replaces the previous `read_until('\n')` loop — which buffered the entire
+//! binary stream looking for a delimiter that never comes — with a bounded,
+//! length-prefixed frame loop over a [`BufferPool`]. Each frame is read into a
+//! pooled buffer, handed to a callback, then recycled; an oversized length is
+//! treated as a security event and ends the connection.
+
+use tokio::io::AsyncRead;
+use tracing::warn;
+
+use super::buffer_pool::BufferPool;
+use super::frame_parser::{read_frame, Frame, FrameError};
+
+/// Outcome of handling a stream to completion.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StreamStats {
+    /// Frames successfully read and dispatched.
+    pub frames: u64,
+    /// Frames rejected for exceeding `MAX_FRAME_SIZE`.
+    pub oversized: u64,
+}
+
+/// Read length-prefixed frames from `reader` until EOF, invoking `on_frame` for
+/// each. Returns the per-stream stats on clean close.
+///
+/// An oversized frame is logged as a security event and ends the stream (the
+/// framing is unrecoverable once a bogus length is read, so the connection is
+/// dropped by the caller). Other I/O errors propagate.
+pub async fn handle_stream<R, F>(
+    reader: &mut R,
+    pool: &BufferPool,
+    mut on_frame: F,
+) -> Result<StreamStats, FrameError>
+where
+    R: AsyncRead + Unpin,
+    F: FnMut(&Frame),
+{
+    let mut stats = StreamStats::default();
+    loop {
+        match read_frame(reader, pool).await {
+            Ok(frame) => {
+                on_frame(&frame);
+                stats.frames += 1;
+                // `frame` drops here, returning its buffer to the pool.
+            }
+            Err(FrameError::Closed) => return Ok(stats),
+            Err(FrameError::FrameTooLarge { length, max }) => {
+                stats.oversized += 1;
+                warn!(
+                    length,
+                    max, "SECURITY: oversized telemetry frame; dropping connection"
+                );
+                return Err(FrameError::FrameTooLarge { length, max });
+            }
+            Err(other) => return Err(other),
+        }
+    }
+}

--- a/tests/ingestion/mod.rs
+++ b/tests/ingestion/mod.rs
@@ -1,0 +1,1 @@
+pub mod stream_test;

--- a/tests/ingestion/stream_test.rs
+++ b/tests/ingestion/stream_test.rs
@@ -125,7 +125,6 @@ async fn test_handle_stream_dispatches_all_frames() {
     .unwrap();
 
     assert_eq!(stats.frames, n);
-    assert_eq!(stats.oversized, 0);
     let got = received.lock();
     assert_eq!(got.len(), n as usize);
     assert_eq!(got[0], 0);

--- a/tests/ingestion/stream_test.rs
+++ b/tests/ingestion/stream_test.rs
@@ -1,0 +1,144 @@
+//! Tests for zero-copy framed ingestion with buffer-pool backpressure (#33).
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use utility_backend::ingestion::buffer_pool::BufferPool;
+use utility_backend::ingestion::frame_parser::{read_frame, FrameError, TelemetryFrame};
+use utility_backend::ingestion::stream_handler::handle_stream;
+
+fn encode(frame: &TelemetryFrame) -> Vec<u8> {
+    let mut payload = Vec::new();
+    ciborium::into_writer(frame, &mut payload).expect("encode");
+    payload
+}
+
+fn framed(payload: &[u8]) -> Vec<u8> {
+    let mut out = (payload.len() as u32).to_be_bytes().to_vec();
+    out.extend_from_slice(payload);
+    out
+}
+
+fn sample(i: u64) -> TelemetryFrame {
+    TelemetryFrame {
+        meter_id: format!("meter-{i}"),
+        timestamp: i,
+        value: i as f64 + 0.5,
+    }
+}
+
+#[tokio::test]
+async fn test_pool_recycles_and_bounds_allocations() {
+    let pool = BufferPool::new(2, 1024);
+    assert_eq!(pool.available(), 2);
+
+    {
+        let _a = pool.acquire().await;
+        let _b = pool.acquire().await;
+        assert_eq!(pool.available(), 0);
+        assert!(pool.try_acquire().is_none(), "exhausted pool backpressures");
+        assert_eq!(pool.allocation_count(), 2);
+    }
+
+    // Both released; reacquiring reuses buffers without new allocations.
+    assert_eq!(pool.available(), 2);
+    let _c = pool.acquire().await;
+    assert_eq!(pool.allocation_count(), 2, "buffer reused, no new alloc");
+}
+
+#[tokio::test]
+async fn test_read_and_decode_frames() {
+    let pool = BufferPool::new(4, 1024);
+    let (f1, f2) = (sample(1), sample(2));
+    let mut data = framed(&encode(&f1));
+    data.extend(framed(&encode(&f2)));
+
+    let mut reader: &[u8] = &data;
+
+    let frame = read_frame(&mut reader, &pool).await.unwrap();
+    assert_eq!(frame.decode::<TelemetryFrame>().unwrap(), f1);
+    drop(frame);
+
+    let frame = read_frame(&mut reader, &pool).await.unwrap();
+    assert_eq!(frame.decode::<TelemetryFrame>().unwrap(), f2);
+    drop(frame);
+
+    assert!(matches!(
+        read_frame(&mut reader, &pool).await,
+        Err(FrameError::Closed)
+    ));
+}
+
+#[tokio::test]
+async fn test_oversized_frame_is_rejected_before_read() {
+    let pool = BufferPool::new(2, 16); // 16-byte buffers
+    let mut data = 100u32.to_be_bytes().to_vec(); // advertises 100 > 16
+    data.extend_from_slice(&[0u8; 100]);
+
+    let mut reader: &[u8] = &data;
+    assert!(matches!(
+        read_frame(&mut reader, &pool).await,
+        Err(FrameError::FrameTooLarge {
+            length: 100,
+            max: 16
+        })
+    ));
+}
+
+#[tokio::test]
+async fn test_held_frame_applies_backpressure() {
+    let pool = BufferPool::new(1, 1024);
+    let mut data = framed(&encode(&sample(1)));
+    data.extend(framed(&encode(&sample(2))));
+
+    let mut reader: &[u8] = &data;
+    let held = read_frame(&mut reader, &pool).await.unwrap();
+    assert_eq!(pool.available(), 0, "the only buffer is in use");
+    assert!(
+        pool.try_acquire().is_none(),
+        "no buffer until the frame drops"
+    );
+
+    drop(held);
+    assert_eq!(pool.available(), 1);
+}
+
+#[tokio::test]
+async fn test_handle_stream_dispatches_all_frames() {
+    let pool = BufferPool::new(8, 1024);
+    let n: u64 = 50;
+    let mut data = Vec::new();
+    for i in 0..n {
+        data.extend(framed(&encode(&sample(i))));
+    }
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let sink = received.clone();
+    let mut reader: &[u8] = &data;
+
+    let stats = handle_stream(&mut reader, &pool, |frame| {
+        let decoded: TelemetryFrame = frame.decode().unwrap();
+        sink.lock().push(decoded.timestamp);
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(stats.frames, n);
+    assert_eq!(stats.oversized, 0);
+    let got = received.lock();
+    assert_eq!(got.len(), n as usize);
+    assert_eq!(got[0], 0);
+    assert_eq!(got[n as usize - 1], n - 1);
+}
+
+#[tokio::test]
+async fn test_handle_stream_rejects_oversized() {
+    let pool = BufferPool::new(2, 16);
+    let mut data = 1000u32.to_be_bytes().to_vec();
+    data.extend_from_slice(&[0u8; 10]);
+
+    let mut reader: &[u8] = &data;
+    let result = handle_stream(&mut reader, &pool, |_| {}).await;
+    assert!(matches!(result, Err(FrameError::FrameTooLarge { .. })));
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod api_tests;
 pub mod gateway_tests;
+pub mod ingestion;
 pub mod settlement;
 pub mod soroban_tests;
 pub mod storage;


### PR DESCRIPTION
# Telemetry Stream Ingestion Memory Backpressure with Zero-Copy Binary Frames (#33)

Closes #33
## What's added (`src/ingestion/`)

| Module | Responsibility |
|---|---|
| `buffer_pool.rs` | `BufferPool` — a `Semaphore`-gated recycling pool (default **1024 × 64 KB = 64 MB**). `acquire()` **awaits** when all buffers are in flight (backpressure to the reader instead of unbounded allocation); released buffers are recycled, so the steady-state allocation rate is ~0 (exposed via `allocation_count()`). |
| `frame_parser.rs` | `read_frame()` reads the `u32` BE length prefix, **validates `length ≤ MAX_FRAME_SIZE` before reading**, then `read_exact()`s exactly `length` bytes into a pooled buffer. CBOR is decoded **zero-copy** straight from the pooled slice (`ciborium::de::from_reader`, no per-frame `Vec`). |
| `stream_handler.rs` | `handle_stream()` — bounded frame loop dispatching each frame to a callback (buffer recycled on drop). An oversized length is logged as a **security event** and ends the connection. |

