### PR TITLE
Service level objective monitoring

### DIFF
--- a/docs/monitoring/slo-burn-rate.md
+++ b/docs/monitoring/slo-burn-rate.md
@@ -1,0 +1,56 @@
+# Service Level Objective monitoring
+
+## Architecture
+
+The API layer records every HTTP response into a process-local SLO monitor and publishes the same observations as Prometheus metrics. The monitor evaluates two objectives system-wide:
+
+- **Availability:** 99.99% of requests must avoid `5xx` responses.
+- **Latency:** 99% of requests must complete within 100 ms to protect critical paths.
+
+A multi-window burn-rate policy compares the fast five-minute window and slow one-hour window. Paging alerts require both windows to exceed their burn thresholds, which reduces noise from brief spikes while still detecting incidents that are actively exhausting the error budget.
+
+## Prometheus metrics
+
+- `utility_slo_requests_total{route,status_class}`: request volume used by SLO calculations.
+- `utility_slo_request_latency_seconds{route}`: request latency histogram.
+- `utility_slo_availability_burn_rate{window="fast|slow"}`: availability error-budget burn.
+- `utility_slo_latency_burn_rate{window="fast|slow"}`: latency error-budget burn.
+- `utility_slo_alert_active`: `1` when the in-process multi-window policy is firing.
+
+## Alert rules
+
+```yaml
+groups:
+  - name: utility-backend-slo
+    rules:
+      - alert: UtilityBackendSLOBurnPage
+        expr: utility_slo_alert_active == 1
+        for: 2m
+        labels:
+          severity: page
+        annotations:
+          summary: Utility backend is rapidly burning SLO error budget
+          description: Investigate 5xx responses and latency above 100 ms before continuing rollout.
+      - alert: UtilityBackendLatencyBudgetTicket
+        expr: utility_slo_latency_burn_rate{window="slow"} >= 6
+        for: 15m
+        labels:
+          severity: ticket
+        annotations:
+          summary: Utility backend latency SLO is burning too quickly
+```
+
+## Dashboard panels
+
+1. Availability by route: `sum(rate(utility_slo_requests_total{status_class!="5xx"}[5m])) / sum(rate(utility_slo_requests_total[5m]))`.
+2. P99 latency by route: `histogram_quantile(0.99, sum by (le, route) (rate(utility_slo_request_latency_seconds_bucket[5m])))`.
+3. Burn rates: plot both `utility_slo_availability_burn_rate` and `utility_slo_latency_burn_rate` by window.
+4. Alert state: single-stat panel for `utility_slo_alert_active`.
+
+## Runbook
+
+1. Confirm `/api/v1/slo/status` and `/metrics` are reachable from the active environment.
+2. Split errors by route with `utility_slo_requests_total{status_class="5xx"}` and inspect recent deployment changes.
+3. Check P99 latency against the 100 ms target and correlate with database pool, Soroban RPC, compaction, and TCP connection metrics.
+4. During blue-green or canary deployment, halt promotion if page-level burn is active for the canary or if canary P99 is worse than baseline by more than 10%.
+5. Roll back the canary/green environment if the burn continues after traffic is reduced.

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -218,6 +218,12 @@ pub async fn clock_state() -> Json<ClockStateResponse> {
     })
 }
 
+pub async fn slo_status() -> Json<crate::observability::slo::SloStatus> {
+    let status = crate::api::slo_state::global_slo_monitor().lock().status();
+    metrics::publish_slo_status(&status);
+    Json(status)
+}
+
 pub async fn readyz_handler() -> StatusCode {
     let starvation = metrics::get_starvation_count();
     if starvation > 100.0 {

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -82,6 +82,36 @@ lazy_static! {
         "Number of TCP frames rejected because their payload exceeded the configured maximum"
     )
     .unwrap();
+
+    pub static ref SLO_REQUESTS_TOTAL: CounterVec = register_counter_vec!(
+        "utility_slo_requests_total",
+        "Total HTTP requests counted for SLO evaluation",
+        &["route", "status_class"]
+    )
+    .unwrap();
+    pub static ref SLO_REQUEST_LATENCY_SECONDS: HistogramVec = register_histogram_vec!(
+        "utility_slo_request_latency_seconds",
+        "HTTP request latency in seconds for SLO evaluation",
+        &["route"]
+    )
+    .unwrap();
+    pub static ref SLO_AVAILABILITY_BURN_RATE: GaugeVec = register_gauge_vec!(
+        "utility_slo_availability_burn_rate",
+        "Availability error-budget burn rate by SLO window",
+        &["window"]
+    )
+    .unwrap();
+    pub static ref SLO_LATENCY_BURN_RATE: GaugeVec = register_gauge_vec!(
+        "utility_slo_latency_burn_rate",
+        "Latency error-budget burn rate by SLO window",
+        &["window"]
+    )
+    .unwrap();
+    pub static ref SLO_ALERT_ACTIVE: Gauge = register_gauge!(
+        "utility_slo_alert_active",
+        "Whether any multi-window SLO burn-rate alert is active"
+    )
+    .unwrap();
     pub static ref TCP_BUFFER_EXCEEDED_RESETS: Counter = register_counter!(
         "tcp_buffer_exceeded_resets",
         "Number of TCP connections reset because their reassembly buffer exceeded the configured maximum"
@@ -311,4 +341,37 @@ pub fn inc_pool_starvation(class: &str) {
     POOL_CLASS_STARVATION_EVENTS
         .with_label_values(&[class])
         .inc();
+}
+
+pub fn record_slo_request(route: &str, status_code: u16, latency_seconds: f64) {
+    let status_class = match status_code {
+        100..=199 => "1xx",
+        200..=299 => "2xx",
+        300..=399 => "3xx",
+        400..=499 => "4xx",
+        500..=599 => "5xx",
+        _ => "unknown",
+    };
+    SLO_REQUESTS_TOTAL
+        .with_label_values(&[route, status_class])
+        .inc();
+    SLO_REQUEST_LATENCY_SECONDS
+        .with_label_values(&[route])
+        .observe(latency_seconds);
+}
+
+pub fn publish_slo_status(status: &crate::observability::slo::SloStatus) {
+    SLO_AVAILABILITY_BURN_RATE
+        .with_label_values(&["fast"])
+        .set(status.fast_window.availability_burn_rate);
+    SLO_AVAILABILITY_BURN_RATE
+        .with_label_values(&["slow"])
+        .set(status.slow_window.availability_burn_rate);
+    SLO_LATENCY_BURN_RATE
+        .with_label_values(&["fast"])
+        .set(status.fast_window.latency_burn_rate);
+    SLO_LATENCY_BURN_RATE
+        .with_label_values(&["slow"])
+        .set(status.slow_window.latency_burn_rate);
+    SLO_ALERT_ACTIVE.set(if status.alert_active { 1.0 } else { 0.0 });
 }

--- a/src/api/middleware.rs
+++ b/src/api/middleware.rs
@@ -472,3 +472,20 @@ mod tests {
         assert!(extended_until > initial_until);
     }
 }
+
+pub async fn slo_monitoring_layer(req: Request<Body>, next: Next) -> Response {
+    let route = req.uri().path().to_string();
+    let started = Instant::now();
+    let response = next.run(req).await;
+    let latency = started.elapsed();
+    crate::api::metrics::record_slo_request(
+        route.as_str(),
+        response.status().as_u16(),
+        latency.as_secs_f64(),
+    );
+    let status = crate::api::slo_state::global_slo_monitor()
+        .lock()
+        .record_request(response.status().as_u16(), latency, Instant::now());
+    crate::api::metrics::publish_slo_status(&status);
+    response
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -12,6 +12,7 @@ pub mod handlers;
 pub mod metrics;
 pub mod middleware;
 pub mod router;
+pub mod slo_state;
 
 #[derive(Clone)]
 pub struct AppState {

--- a/src/api/router.rs
+++ b/src/api/router.rs
@@ -46,12 +46,16 @@ pub async fn build_router(state: AppState) -> anyhow::Result<Router> {
             "/api/v1/rate-limiter/status",
             get(handlers::rate_limiter_status),
         )
+        .route("/api/v1/slo/status", get(handlers::slo_status))
         .layer(axum_mw::from_fn_with_state(
             state.clone(),
             crate::api::middleware::rate_limit_layer,
         ))
         .layer(axum_mw::from_fn(
             crate::gateway::telemetry::tracing_middleware,
+        ))
+        .layer(axum_mw::from_fn(
+            crate::api::middleware::slo_monitoring_layer,
         ))
         .layer(cors)
         .with_state(state);

--- a/src/api/slo_state.rs
+++ b/src/api/slo_state.rs
@@ -1,0 +1,12 @@
+use crate::observability::slo::{SloConfig, SloMonitor};
+use lazy_static::lazy_static;
+use parking_lot::Mutex;
+
+lazy_static! {
+    static ref GLOBAL_SLO_MONITOR: Mutex<SloMonitor> =
+        Mutex::new(SloMonitor::new(SloConfig::default()));
+}
+
+pub fn global_slo_monitor() -> &'static Mutex<SloMonitor> {
+    &GLOBAL_SLO_MONITOR
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod identity;
 pub mod ingestion;
 pub mod lifecycle;
 pub mod memory;
+pub mod observability;
 pub mod ratelimit;
 pub mod settlement;
 pub mod soroban;

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,0 +1,1 @@
+pub mod slo;

--- a/src/observability/slo.rs
+++ b/src/observability/slo.rs
@@ -1,0 +1,241 @@
+use serde::Serialize;
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug)]
+pub struct SloConfig {
+    pub availability_target: f64,
+    pub latency_target: f64,
+    pub latency_threshold: Duration,
+    pub fast_window: Duration,
+    pub slow_window: Duration,
+    pub fast_burn_threshold: f64,
+    pub slow_burn_threshold: f64,
+}
+
+impl Default for SloConfig {
+    fn default() -> Self {
+        Self {
+            availability_target: 0.9999,
+            latency_target: 0.99,
+            latency_threshold: Duration::from_millis(100),
+            fast_window: Duration::from_secs(5 * 60),
+            slow_window: Duration::from_secs(60 * 60),
+            fast_burn_threshold: 14.4,
+            slow_burn_threshold: 6.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RequestSample {
+    at: Instant,
+    success: bool,
+    latency: Duration,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub enum AlertSeverity {
+    Page,
+    Ticket,
+    Healthy,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SloWindowStatus {
+    pub window_seconds: u64,
+    pub total_requests: u64,
+    pub availability: f64,
+    pub latency_compliance: f64,
+    pub availability_burn_rate: f64,
+    pub latency_burn_rate: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SloStatus {
+    pub availability_target: f64,
+    pub latency_target: f64,
+    pub latency_threshold_ms: u64,
+    pub fast_window: SloWindowStatus,
+    pub slow_window: SloWindowStatus,
+    pub severity: AlertSeverity,
+    pub alert_active: bool,
+}
+
+#[derive(Debug)]
+pub struct SloMonitor {
+    config: SloConfig,
+    samples: VecDeque<RequestSample>,
+}
+
+impl SloMonitor {
+    pub fn new(config: SloConfig) -> Self {
+        Self {
+            config,
+            samples: VecDeque::new(),
+        }
+    }
+
+    pub fn record_request(
+        &mut self,
+        status_code: u16,
+        latency: Duration,
+        now: Instant,
+    ) -> SloStatus {
+        let success = status_code < 500;
+        self.samples.push_back(RequestSample {
+            at: now,
+            success,
+            latency,
+        });
+        self.prune(now);
+        self.status_at(now)
+    }
+
+    pub fn status(&mut self) -> SloStatus {
+        let now = Instant::now();
+        self.prune(now);
+        self.status_at(now)
+    }
+
+    fn prune(&mut self, now: Instant) {
+        while self
+            .samples
+            .front()
+            .is_some_and(|s| now.duration_since(s.at) > self.config.slow_window)
+        {
+            self.samples.pop_front();
+        }
+    }
+
+    fn window_status(&self, now: Instant, window: Duration) -> SloWindowStatus {
+        let mut total = 0_u64;
+        let mut failures = 0_u64;
+        let mut slow = 0_u64;
+        for sample in self
+            .samples
+            .iter()
+            .filter(|s| now.duration_since(s.at) <= window)
+        {
+            total += 1;
+            if !sample.success {
+                failures += 1;
+            }
+            if sample.latency > self.config.latency_threshold {
+                slow += 1;
+            }
+        }
+        let availability = ratio(total - failures, total);
+        let latency_compliance = ratio(total - slow, total);
+        SloWindowStatus {
+            window_seconds: window.as_secs(),
+            total_requests: total,
+            availability,
+            latency_compliance,
+            availability_burn_rate: burn_rate(
+                1.0 - availability,
+                1.0 - self.config.availability_target,
+            ),
+            latency_burn_rate: burn_rate(
+                1.0 - latency_compliance,
+                1.0 - self.config.latency_target,
+            ),
+        }
+    }
+
+    fn status_at(&self, now: Instant) -> SloStatus {
+        let fast_window = self.window_status(now, self.config.fast_window);
+        let slow_window = self.window_status(now, self.config.slow_window);
+        let fast_burn = fast_window
+            .availability_burn_rate
+            .max(fast_window.latency_burn_rate);
+        let slow_burn = slow_window
+            .availability_burn_rate
+            .max(slow_window.latency_burn_rate);
+        let severity = if fast_burn >= self.config.fast_burn_threshold
+            && slow_burn >= self.config.slow_burn_threshold
+        {
+            AlertSeverity::Page
+        } else if slow_burn >= self.config.slow_burn_threshold {
+            AlertSeverity::Ticket
+        } else {
+            AlertSeverity::Healthy
+        };
+        let alert_active = severity != AlertSeverity::Healthy;
+        SloStatus {
+            availability_target: self.config.availability_target,
+            latency_target: self.config.latency_target,
+            latency_threshold_ms: self.config.latency_threshold.as_millis() as u64,
+            fast_window,
+            slow_window,
+            severity,
+            alert_active,
+        }
+    }
+}
+
+fn ratio(numerator: u64, denominator: u64) -> f64 {
+    if denominator == 0 {
+        1.0
+    } else {
+        numerator as f64 / denominator as f64
+    }
+}
+
+fn burn_rate(error_ratio: f64, error_budget: f64) -> f64 {
+    if error_budget <= f64::EPSILON {
+        0.0
+    } else {
+        error_ratio / error_budget
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn monitor() -> SloMonitor {
+        SloMonitor::new(SloConfig {
+            fast_window: Duration::from_secs(60),
+            slow_window: Duration::from_secs(600),
+            ..SloConfig::default()
+        })
+    }
+
+    #[test]
+    fn healthy_traffic_does_not_alert() {
+        let mut slo = monitor();
+        let now = Instant::now();
+        for i in 0..100 {
+            slo.record_request(200, Duration::from_millis(20), now + Duration::from_secs(i));
+        }
+        let status = slo.status_at(now + Duration::from_secs(100));
+        assert_eq!(status.severity, AlertSeverity::Healthy);
+        assert_eq!(status.slow_window.availability, 1.0);
+    }
+
+    #[test]
+    fn sustained_failures_page_on_multi_window_burn() {
+        let mut slo = monitor();
+        let now = Instant::now();
+        for i in 0..100 {
+            slo.record_request(
+                if i < 10 { 500 } else { 200 },
+                Duration::from_millis(20),
+                now + Duration::from_secs(i),
+            );
+        }
+        let status = slo.status_at(now + Duration::from_secs(100));
+        assert_eq!(status.severity, AlertSeverity::Page);
+        assert!(status.fast_window.availability_burn_rate > 14.4);
+    }
+
+    #[test]
+    fn slow_requests_consume_latency_error_budget() {
+        let mut slo = monitor();
+        let now = Instant::now();
+        slo.record_request(200, Duration::from_millis(150), now);
+        let status = slo.status_at(now);
+        assert!(status.slow_window.latency_burn_rate >= 100.0);
+    }
+}


### PR DESCRIPTION
Motivation
Provide a process-local SLO monitoring system to detect systemic availability and latency regressions during rollouts and normal operation using multi-window burn-rate logic.
Target objectives mirror operational goals: 99.99% availability and protecting P99 latency (100 ms) for critical paths.
Expose in-process SLO state and derived Prometheus metrics to drive alerts, dashboards, and runbook actions for canary / blue-green deployments.
Description
Add a new observability::slo module implementing a SloMonitor with multi-window (fast/slow) burn-rate evaluation, severity classification (Page/Ticket/Healthy) and unit tests.
Add a global SLO monitor (src/api/slo_state.rs) and wire it into the HTTP stack via a new middleware slo_monitoring_layer that records every response's status and latency.
Publish Prometheus metrics (utility_slo_requests_total, utility_slo_request_latency_seconds, utility_slo_availability_burn_rate, utility_slo_latency_burn_rate, utility_slo_alert_active) and helper functions in src/api/metrics.rs.
Add an API endpoint /api/v1/slo/status returning the current SloStatus and publish the computed burn-rate gauges on query, and integrate the middleware and endpoint into the router and library module list.
Add documentation docs/monitoring/slo-burn-rate.md describing architecture, alert rules, dashboard panels, and runbook guidance.
Testing
Ran cargo fmt and git diff --check successfully.
Attempted cargo test slo --all-targets --offline but execution was blocked by a toolchain mismatch where local rustc 1.89.0 is incompatible with fixed 1.31.0 (requires rustc 1.93), so unit tests could not be run end-to-end in this environment.
Attempted cargo update -p fixed --precise 1.29.0 && cargo test slo --all-targets to resolve the toolchain issue, but cargo update failed due to network/crates.io access (CONNECT tunnel 403), so tests remain unexecuted in CI here.
Closes https://github.com/Utility-Protocol/utility-backend/issues/143