### PR TITLE
Kafka consumer lag monitoring

### DIFF
--- a/docs/kafka-consumer-lag-autoscaling.md
+++ b/docs/kafka-consumer-lag-autoscaling.md
@@ -1,0 +1,51 @@
+# Kafka Consumer Lag Monitoring and Autoscaling
+
+## Architecture
+
+The lag controller runs as a system-wide background control loop outside the request and ingestion hot paths. It periodically samples Kafka committed offsets and topic high-watermarks, converts them into `ConsumerGroupLagSnapshot` values, evaluates each group with `evaluate_scaling`, and submits replica changes to the deployment layer only after cooldown and rollout gates pass.
+
+```text
+Kafka Admin/ListOffsets APIs
+        │
+        ▼
+Lag sampler ──► Prometheus metrics ──► alerts + dashboards
+        │
+        ▼
+Scaling policy evaluator ──► blue/green deployer ──► canary analysis ──► consumer group replicas
+```
+
+## Core policy
+
+The policy computes total lag and maximum partition lag for each group. Desired replicas are derived from `lag_per_replica`, clamped by minimum replicas, maximum replicas, and the partition count to avoid over-provisioning idle consumers. Scale-up only happens at or above `scale_up_threshold`; scale-down only happens at or below `scale_down_threshold`, which creates hysteresis and protects the 99.99% availability target from oscillation.
+
+## Monitoring and alerting
+
+Recommended metrics:
+
+- `utility_kafka_consumer_group_lag{group,topic}`: total group lag.
+- `utility_kafka_consumer_group_partition_lag{group,topic,partition}`: partition lag distribution.
+- `utility_kafka_consumer_group_desired_replicas{group}`: latest policy output.
+- `utility_kafka_consumer_group_scaling_decisions_total{group,reason}`: scale up, scale down, and stable decisions.
+- `utility_kafka_consumer_group_lag_alerts_total{group,severity}`: warning and critical lag alerts.
+
+Alert rules:
+
+- Warning: total lag remains above the scale-up threshold for two sampling windows.
+- Critical: total lag exceeds `critical_lag_threshold` or the oldest message age breaches the service SLO.
+- Page: lag is critical and canary analysis blocks scale-up, because manual intervention may be required.
+
+Dashboards should show total lag, max partition lag, consumer group members, desired replicas, actual replicas, rebalance counts, error rates, and P99 processing latency on one screen per domain service.
+
+## Deployment strategy
+
+1. Deploy the controller in blue/green mode with scaling writes disabled and compare computed desired replicas against current production behavior.
+2. Enable write mode for one low-risk consumer group as a canary.
+3. Promote canary only if lag decreases, P99 processing latency remains below 100 ms, error rate does not regress, and rebalance time stays within the service budget.
+4. Roll forward one domain at a time. Roll back by disabling scaling writes; monitoring remains read-only.
+
+## Security review notes
+
+- Use least-privilege Kafka credentials that can read offsets and group metadata only.
+- Use deployment credentials scoped to consumer group replica targets, not cluster-admin access.
+- Treat group names and topic names as controlled labels to prevent metric-cardinality attacks.
+- Audit every scale action with actor, group, previous replicas, desired replicas, reason, and canary result.

--- a/runbooks/kafka-consumer-lag.md
+++ b/runbooks/kafka-consumer-lag.md
@@ -1,0 +1,18 @@
+# Runbook: Kafka Consumer Lag
+
+## Triage
+
+1. Open the Kafka lag dashboard and identify groups with warning or critical alerts.
+2. Check total lag, max partition lag, oldest message age, actual replicas, and desired replicas.
+3. Confirm Kafka broker health and partition leadership before changing consumer replicas manually.
+4. If lag is critical and autoscaling is blocked, inspect canary analysis output for latency, error-rate, or rebalance regressions.
+
+## Manual mitigation
+
+- If broker health is normal and processing latency is below 100 ms P99, increase replicas up to the partition count.
+- If a single partition dominates lag, investigate poison messages, downstream throttling, and partition-key skew.
+- If all partitions are lagging and P99 latency is high, prioritize downstream dependency recovery before adding replicas.
+
+## Rollback
+
+Disable scaling writes for the affected group. The lag controller should continue emitting read-only metrics and alerts while deployment ownership returns to the operator.

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -67,6 +67,38 @@ lazy_static! {
         "Chunk compaction duration in milliseconds"
     )
     .unwrap();
+
+    pub static ref KAFKA_CONSUMER_GROUP_LAG: GaugeVec = register_gauge_vec!(
+        "utility_kafka_consumer_group_lag",
+        "Total lag per Kafka consumer group and topic",
+        &["group", "topic"]
+    )
+    .unwrap();
+    pub static ref KAFKA_CONSUMER_GROUP_PARTITION_LAG: GaugeVec = register_gauge_vec!(
+        "utility_kafka_consumer_group_partition_lag",
+        "Lag per Kafka consumer group topic partition",
+        &["group", "topic", "partition"]
+    )
+    .unwrap();
+    pub static ref KAFKA_CONSUMER_GROUP_DESIRED_REPLICAS: GaugeVec = register_gauge_vec!(
+        "utility_kafka_consumer_group_desired_replicas",
+        "Desired replicas computed by the Kafka consumer group autoscaler",
+        &["group"]
+    )
+    .unwrap();
+    pub static ref KAFKA_CONSUMER_GROUP_SCALING_DECISIONS: CounterVec = register_counter_vec!(
+        "utility_kafka_consumer_group_scaling_decisions_total",
+        "Kafka consumer group autoscaling decisions",
+        &["group", "reason"]
+    )
+    .unwrap();
+    pub static ref KAFKA_CONSUMER_GROUP_LAG_ALERTS: CounterVec = register_counter_vec!(
+        "utility_kafka_consumer_group_lag_alerts_total",
+        "Kafka consumer group lag alerts emitted by severity",
+        &["group", "severity"]
+    )
+    .unwrap();
+
     pub static ref TCP_PARTIAL_FRAMES_BUFFERED: Counter = register_counter!(
         "tcp_partial_frames_buffered",
         "Number of TCP reads buffered by the frame reassembly layer"
@@ -117,6 +149,36 @@ pub fn set_db_waiting_requests(count: f64) {
 
 pub fn get_starvation_count() -> f64 {
     DB_POOL_STARVATION.get()
+}
+
+pub fn set_kafka_consumer_group_lag(group: &str, topic: &str, lag: f64) {
+    KAFKA_CONSUMER_GROUP_LAG
+        .with_label_values(&[group, topic])
+        .set(lag);
+}
+
+pub fn set_kafka_consumer_group_partition_lag(group: &str, topic: &str, partition: i32, lag: f64) {
+    KAFKA_CONSUMER_GROUP_PARTITION_LAG
+        .with_label_values(&[group, topic, &partition.to_string()])
+        .set(lag);
+}
+
+pub fn set_kafka_consumer_group_desired_replicas(group: &str, replicas: u32) {
+    KAFKA_CONSUMER_GROUP_DESIRED_REPLICAS
+        .with_label_values(&[group])
+        .set(replicas as f64);
+}
+
+pub fn record_kafka_consumer_group_scaling_decision(group: &str, reason: &str) {
+    KAFKA_CONSUMER_GROUP_SCALING_DECISIONS
+        .with_label_values(&[group, reason])
+        .inc();
+}
+
+pub fn record_kafka_consumer_group_lag_alert(group: &str, severity: &str) {
+    KAFKA_CONSUMER_GROUP_LAG_ALERTS
+        .with_label_values(&[group, severity])
+        .inc();
 }
 
 pub fn record_compaction_attempt() {

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -1,0 +1,159 @@
+//! Kafka consumer lag monitoring and autoscaling policy evaluation.
+//!
+//! This module intentionally keeps broker/Kubernetes integrations behind simple
+//! data structures so lag sampling stays off the ingestion critical path. A
+//! background controller can feed [`ConsumerGroupLagSnapshot`] values from Kafka
+//! Admin/ListOffsets APIs and apply the returned [`ScalingDecision`] through the
+//! deployment platform.
+
+use std::time::Duration;
+
+/// Lag for a single topic partition assigned to a consumer group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionLag {
+    pub topic: String,
+    pub partition: i32,
+    pub current_offset: i64,
+    pub high_watermark: i64,
+}
+
+impl PartitionLag {
+    pub fn lag(&self) -> u64 {
+        self.high_watermark.saturating_sub(self.current_offset) as u64
+    }
+}
+
+/// Aggregated lag sample for one consumer group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsumerGroupLagSnapshot {
+    pub group_id: String,
+    pub members: u32,
+    pub partitions: Vec<PartitionLag>,
+}
+
+impl ConsumerGroupLagSnapshot {
+    pub fn total_lag(&self) -> u64 {
+        self.partitions.iter().map(PartitionLag::lag).sum()
+    }
+
+    pub fn max_partition_lag(&self) -> u64 {
+        self.partitions
+            .iter()
+            .map(PartitionLag::lag)
+            .max()
+            .unwrap_or(0)
+    }
+
+    pub fn partition_count(&self) -> u32 {
+        self.partitions.len() as u32
+    }
+}
+
+/// Autoscaling bounds and alert thresholds for a consumer group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsumerGroupScalingPolicy {
+    pub min_replicas: u32,
+    pub max_replicas: u32,
+    pub lag_per_replica: u64,
+    pub scale_up_threshold: u64,
+    pub scale_down_threshold: u64,
+    pub critical_lag_threshold: u64,
+    pub cooldown: Duration,
+}
+
+impl Default for ConsumerGroupScalingPolicy {
+    fn default() -> Self {
+        Self {
+            min_replicas: 1,
+            max_replicas: 32,
+            lag_per_replica: 10_000,
+            scale_up_threshold: 20_000,
+            scale_down_threshold: 1_000,
+            critical_lag_threshold: 100_000,
+            cooldown: Duration::from_secs(120),
+        }
+    }
+}
+
+/// Result from evaluating a lag snapshot against an autoscaling policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScalingDecision {
+    pub desired_replicas: u32,
+    pub reason: ScalingReason,
+    pub alert: Option<LagAlert>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalingReason {
+    ScaleUp,
+    ScaleDown,
+    Stable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LagAlert {
+    pub severity: AlertSeverity,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertSeverity {
+    Warning,
+    Critical,
+}
+
+pub fn evaluate_scaling(
+    snapshot: &ConsumerGroupLagSnapshot,
+    current_replicas: u32,
+    policy: &ConsumerGroupScalingPolicy,
+) -> ScalingDecision {
+    let total_lag = snapshot.total_lag();
+    let max_replicas = policy.max_replicas.max(policy.min_replicas);
+    let current = current_replicas.clamp(policy.min_replicas, max_replicas);
+    let partitions = snapshot.partition_count().max(1);
+    let replica_ceiling = max_replicas.min(partitions);
+
+    let target_by_lag = if total_lag == 0 {
+        policy.min_replicas
+    } else {
+        total_lag.div_ceil(policy.lag_per_replica.max(1)) as u32
+    };
+    let target = target_by_lag.clamp(
+        policy.min_replicas,
+        replica_ceiling.max(policy.min_replicas),
+    );
+
+    let (desired_replicas, reason) = if total_lag >= policy.scale_up_threshold && target > current {
+        (target, ScalingReason::ScaleUp)
+    } else if total_lag <= policy.scale_down_threshold && target < current {
+        (target, ScalingReason::ScaleDown)
+    } else {
+        (current, ScalingReason::Stable)
+    };
+
+    let alert = if total_lag >= policy.critical_lag_threshold {
+        Some(LagAlert {
+            severity: AlertSeverity::Critical,
+            message: format!(
+                "consumer group {} lag {} exceeds critical threshold {}",
+                snapshot.group_id, total_lag, policy.critical_lag_threshold
+            ),
+        })
+    } else if total_lag >= policy.scale_up_threshold {
+        Some(LagAlert {
+            severity: AlertSeverity::Warning,
+            message: format!(
+                "consumer group {} lag {} requires additional capacity",
+                snapshot.group_id, total_lag
+            ),
+        })
+    } else {
+        None
+    };
+
+    ScalingDecision {
+        desired_replicas,
+        reason,
+        alert,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod blockchain;
 pub mod gateway;
 pub mod identity;
 pub mod ingestion;
+pub mod kafka;
 pub mod lifecycle;
 pub mod memory;
 pub mod ratelimit;

--- a/tests/kafka/mod.rs
+++ b/tests/kafka/mod.rs
@@ -1,0 +1,81 @@
+use std::time::Duration;
+
+use utility_backend::kafka::{
+    evaluate_scaling, AlertSeverity, ConsumerGroupLagSnapshot, ConsumerGroupScalingPolicy,
+    PartitionLag, ScalingReason,
+};
+
+fn policy() -> ConsumerGroupScalingPolicy {
+    ConsumerGroupScalingPolicy {
+        min_replicas: 2,
+        max_replicas: 10,
+        lag_per_replica: 1_000,
+        scale_up_threshold: 2_000,
+        scale_down_threshold: 250,
+        critical_lag_threshold: 8_000,
+        cooldown: Duration::from_secs(60),
+    }
+}
+
+fn snapshot(lags: &[u64]) -> ConsumerGroupLagSnapshot {
+    ConsumerGroupLagSnapshot {
+        group_id: "settlement-writer".to_string(),
+        members: 2,
+        partitions: lags
+            .iter()
+            .enumerate()
+            .map(|(partition, lag)| PartitionLag {
+                topic: "utility.events".to_string(),
+                partition: partition as i32,
+                current_offset: 10,
+                high_watermark: 10 + *lag as i64,
+            })
+            .collect(),
+    }
+}
+
+#[test]
+fn computes_total_and_max_partition_lag() {
+    let sample = snapshot(&[100, 5_000, 1_250]);
+
+    assert_eq!(sample.total_lag(), 6_350);
+    assert_eq!(sample.max_partition_lag(), 5_000);
+}
+
+#[test]
+fn scales_up_and_caps_at_partition_count() {
+    let decision = evaluate_scaling(&snapshot(&[2_500, 2_000, 2_000]), 2, &policy());
+
+    assert_eq!(decision.reason, ScalingReason::ScaleUp);
+    assert_eq!(decision.desired_replicas, 3);
+    assert_eq!(decision.alert.unwrap().severity, AlertSeverity::Warning);
+}
+
+#[test]
+fn scales_down_when_lag_is_below_threshold() {
+    let decision = evaluate_scaling(&snapshot(&[10, 20, 30, 40]), 6, &policy());
+
+    assert_eq!(decision.reason, ScalingReason::ScaleDown);
+    assert_eq!(decision.desired_replicas, 2);
+    assert!(decision.alert.is_none());
+}
+
+#[test]
+fn emits_critical_alert_for_excessive_lag() {
+    let decision = evaluate_scaling(&snapshot(&[4_500, 4_000]), 2, &policy());
+
+    assert_eq!(decision.desired_replicas, 2);
+    assert_eq!(decision.alert.unwrap().severity, AlertSeverity::Critical);
+}
+
+#[test]
+fn saturates_negative_offsets_to_zero_lag() {
+    let lag = PartitionLag {
+        topic: "utility.events".to_string(),
+        partition: 0,
+        current_offset: 42,
+        high_watermark: 10,
+    };
+
+    assert_eq!(lag.lag(), 0);
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -10,3 +10,5 @@ pub mod storage;
 pub mod tariffs_tests;
 pub mod time_series_tests;
 pub mod transport;
+
+mod kafka;


### PR DESCRIPTION
Motivation
Provide a system-wide controller-friendly representation of Kafka consumer group lag and a deterministic autoscaling policy to keep consumer lag within SLOs.
Expose Prometheus metrics and helpers so the controller and dashboards can observe group/partition lag and scaling decisions.
Ship operational documentation and a runbook to support safe blue/green/canary rollout and on-call triage.
Description
Add a new kafka module implementing PartitionLag, ConsumerGroupLagSnapshot, ConsumerGroupScalingPolicy, ScalingDecision, LagAlert, and the evaluate_scaling function to derive desired replicas and alerts from a lag snapshot (src/kafka/mod.rs).
Register new Prometheus metrics and add helper setters/counters for consumer group total lag, partition lag, desired replicas, scaling decisions, and lag alerts in src/api/metrics.rs.
Export the kafka module from the crate root by adding pub mod kafka; to src/lib.rs and wire tests into the test suite by updating tests/mod.rs.
Add unit tests covering lag aggregation, scale-up and cap behavior, scale-down hysteresis, critical alert emission, and negative-offset handling (tests/kafka/mod.rs).
Add design and operational documentation at docs/kafka-consumer-lag-autoscaling.md and a runbook at runbooks/kafka-consumer-lag.md describing architecture, monitoring, alerts, deployment strategy, and manual mitigation steps.
Testing
cargo fmt --check succeeded.
git diff --check succeeded.
cargo test kafka --no-default-features --offline was attempted but blocked due to the environment using rustc 1.89.0 while the locked fixed dependency requires rustc 1.93.
cargo test kafka --no-default-features was attempted but blocked by failure to access the crates.io index (HTTP 403 CONNECT tunnel error) during dependency resolution.
Closes https://github.com/Utility-Protocol/utility-backend/issues/123