### PR TITLE
Docker image layer caching optimization

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -20,11 +20,8 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      - name: Cache cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
 
       - name: Rustfmt check
         run: cargo fmt --all -- --check
@@ -55,11 +52,8 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo build
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('Cargo.lock') }}
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
 
       - name: Run database migrations
         run: |
@@ -77,7 +71,18 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Build Docker image
-        run: docker build -t utility-backend .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and cache Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          tags: utility-backend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,30 @@
-FROM rust:slim AS builder
-
+FROM lukemathwalker/cargo-chef:latest-rust-1-slim AS chef
 WORKDIR /app
-RUN apt-get update && apt-get install -y pkg-config libssl-dev build-essential cmake libclang-dev && rm -rf /var/lib/apt/lists/*
 
-COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo "fn main() {}" > src/main.rs
-RUN cargo build --release 2>/dev/null || true
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
+FROM chef AS builder
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    build-essential \
+    cmake \
+    libclang-dev \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=planner /app/recipe.json recipe.json
+# Build and cache third-party dependencies
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Copy full application source and compile the backend
 COPY . .
 RUN cargo build --release
 
+# Final runtime image
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates libssl3 && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ cargo test --all-features
 cargo clippy --all-targets -- -D warnings
 ```
 
-## CI/CD
+## CI/CD & Caching Optimizations
 
 GitHub Actions runs lint, type-check, and Dockerized database tests on every commit.
+
+To optimize build and CI performance, the repository utilizes advanced Docker and Cargo caching mechanisms:
+
+### 1. Docker Multi-Stage Builds with `cargo-chef`
+The `Dockerfile` employs a multi-stage compilation flow using `lukemathwalker/cargo-chef` to isolate external dependency builds from internal source changes:
+* **Planner Stage**: Analyzes the project structure to generate a minimal dependency recipe (`recipe.json`).
+* **Builder Stage**: Installs development system packages and runs `cargo chef cook` to compile third-party dependencies. This layer remains cached unless `Cargo.lock` changes.
+* **Compiler Stage**: Copies the remaining application code and performs a rapid compile of only the workspace crates.
+* **Runner Stage**: Employs `debian:bookworm-slim` for a minimal, secure production-ready execution footprint.
+
+### 2. CI Runner Caching
+Our `.github/workflows/backend-ci.yml` CI workflow is optimized to save time and system resources:
+* **GitHub Actions Layer Cache (`type=gha`)**: Configured with Docker Buildx and `docker/build-push-action@v6` to persist all intermediate image layers directly inside the GitHub Actions virtual machine runner cache using `mode=max`.
+* **Rust/Cargo Caching (`swatinem/rust-cache@v2`)**: Replaced manual cargo home caching to securely, safely, and transparently cache cargo indexes, git databases, registry downloads, and built target directory objects. This yields significant build-time savings across commits.


### PR DESCRIPTION
We have optimized Docker image layer caching and CI performance:

Updated the Dockerfile to use lukemathwalker/cargo-chef for separating external cargo dependency compilation from application source compilations.
Modified .github/workflows/backend-ci.yml to utilize Docker Buildx and docker/build-push-action@v6 with GHA caching (cache-from: type=gha and cache-to: type=gha,mode=max).
Integrated swatinem/rust-cache@v2 across lint-check-type and test jobs for robust Rust compilation caches.
Updated documentation in README.md explaining the caching architecture and pipeline optimizations.
Closes https://github.com/Utility-Protocol/utility-backend/issues/137