### PR TITLE
feat: add service health check aggregation endpoint

### DIFF
--- a/src/api/health.rs
+++ b/src/api/health.rs
@@ -1,0 +1,266 @@
+use crate::api::AppState;
+use axum::{extract::State, Json};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+use crate::service_mesh::client::{ServiceMeshClient, ServiceMeshDiscovery};
+use crate::service_mesh::{MeshIdentity, ServiceMeshMtlsConfig};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum HealthStatus {
+    Up,
+    Down,
+    Degraded,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DetailedHealthResponse {
+    pub status: HealthStatus,
+    pub timestamp: String,
+    pub services: HashMap<String, ServiceHealth>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SummaryHealthResponse {
+    pub status: HealthStatus,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ServiceHealth {
+    pub status: HealthStatus,
+    pub error: Option<String>,
+}
+
+pub struct HealthCircuitBreaker {
+    failures: u32,
+    state: CircuitState,
+    last_failure: Option<Instant>,
+}
+
+enum CircuitState {
+    Closed,
+    Open,
+}
+
+impl HealthCircuitBreaker {
+    pub fn new() -> Self {
+        Self {
+            failures: 0,
+            state: CircuitState::Closed,
+            last_failure: None,
+        }
+    }
+
+    pub fn admit(&mut self) -> bool {
+        match self.state {
+            CircuitState::Closed => true,
+            CircuitState::Open => {
+                if let Some(last) = self.last_failure {
+                    if last.elapsed() > Duration::from_secs(30) {
+                        self.state = CircuitState::Closed;
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
+
+    pub fn record_result(&mut self, success: bool) {
+        if success {
+            self.failures = 0;
+            self.state = CircuitState::Closed;
+        } else {
+            self.failures += 1;
+            if self.failures >= 3 {
+                self.state = CircuitState::Open;
+                self.last_failure = Some(Instant::now());
+            }
+        }
+    }
+}
+
+pub struct HealthAggregator {
+    cache: RwLock<Option<(Instant, DetailedHealthResponse)>>,
+    circuit_breakers: RwLock<HashMap<String, HealthCircuitBreaker>>,
+    discovery: Arc<ServiceMeshDiscovery>,
+    mtls_config: ServiceMeshMtlsConfig,
+    identity: MeshIdentity,
+}
+
+impl HealthAggregator {
+    pub fn new(
+        discovery: Arc<ServiceMeshDiscovery>,
+        mtls_config: ServiceMeshMtlsConfig,
+        identity: MeshIdentity,
+    ) -> Self {
+        Self {
+            cache: RwLock::new(None),
+            circuit_breakers: RwLock::new(HashMap::new()),
+            discovery,
+            mtls_config,
+            identity,
+        }
+    }
+
+    pub async fn get_health(&self) -> DetailedHealthResponse {
+        {
+            let cache = self.cache.read().await;
+            if let Some((ts, response)) = &*cache {
+                if ts.elapsed() < Duration::from_secs(10) {
+                    return response.clone();
+                }
+            }
+        }
+
+        let endpoints = self.discovery.list().await;
+
+        let client = match ServiceMeshClient::new(&self.mtls_config, &self.identity, endpoints.clone()).await {
+            Ok(c) => Arc::new(c),
+            Err(e) => {
+                let mut services = HashMap::new();
+                for ep in endpoints {
+                    services.insert(
+                        ep.name,
+                        ServiceHealth {
+                            status: HealthStatus::Down,
+                            error: Some(format!("Client init error: {}", e)),
+                        },
+                    );
+                }
+                return DetailedHealthResponse {
+                    status: HealthStatus::Down,
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                    services,
+                };
+            }
+        };
+
+        let mut futures = vec![];
+
+        for endpoint in endpoints {
+            let client = client.clone();
+            let name = endpoint.name.clone();
+
+            let mut admit = true;
+            {
+                let mut breakers = self.circuit_breakers.write().await;
+                let breaker = breakers
+                    .entry(name.clone())
+                    .or_insert_with(HealthCircuitBreaker::new);
+                admit = breaker.admit();
+            }
+
+            if !admit {
+                futures.push(async move { (name, Err("Circuit breaker open".to_string())) });
+                continue;
+            }
+
+            futures.push(async move {
+                let res = client.check_health(&name).await;
+                (name, res.map_err(|e| e.to_string()))
+            });
+        }
+
+        let results = futures::future::join_all(futures).await;
+
+        let mut services = HashMap::new();
+        let mut all_up = true;
+        let mut any_up = false;
+
+        {
+            let mut breakers = self.circuit_breakers.write().await;
+
+            for (name, res) in results {
+                let breaker = breakers
+                    .entry(name.clone())
+                    .or_insert_with(HealthCircuitBreaker::new);
+
+                let health = match res {
+                    Ok(_) => {
+                        breaker.record_result(true);
+                        any_up = true;
+                        ServiceHealth {
+                            status: HealthStatus::Up,
+                            error: None,
+                        }
+                    }
+                    Err(e) => {
+                        breaker.record_result(false);
+                        all_up = false;
+                        ServiceHealth {
+                            status: HealthStatus::Down,
+                            error: Some(e),
+                        }
+                    }
+                };
+
+                let val = if matches!(health.status, HealthStatus::Up) {
+                    1.0
+                } else {
+                    0.0
+                };
+                crate::api::metrics::set_health_status(&name, val);
+
+                services.insert(name, health);
+            }
+        }
+
+        let status = if services.is_empty() {
+            HealthStatus::Up
+        } else if all_up {
+            HealthStatus::Up
+        } else if any_up {
+            HealthStatus::Degraded
+        } else {
+            HealthStatus::Down
+        };
+
+        let response = DetailedHealthResponse {
+            status,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            services,
+        };
+
+        {
+            let mut cache = self.cache.write().await;
+            *cache = Some((Instant::now(), response.clone()));
+        }
+
+        response
+    }
+}
+
+pub async fn summary_health(State(state): State<AppState>) -> Json<SummaryHealthResponse> {
+    let detailed = state.health_aggregator.get_health().await;
+    Json(SummaryHealthResponse {
+        status: detailed.status,
+    })
+}
+
+pub async fn detailed_health(State(state): State<AppState>) -> Json<DetailedHealthResponse> {
+    let detailed = state.health_aggregator.get_health().await;
+    Json(detailed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn circuit_breaker_opens_and_half_opens() {
+        let mut cb = HealthCircuitBreaker::new();
+        assert!(cb.admit());
+        cb.record_result(false);
+        cb.record_result(false);
+        assert!(cb.admit());
+        cb.record_result(false); // 3rd failure
+        assert!(!cb.admit()); // open
+
+        cb.last_failure = Some(Instant::now() - Duration::from_secs(31));
+        assert!(cb.admit()); // should allow probe
+    }
+}

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -775,3 +775,18 @@ pub fn inc_job_scheduler_failed() {
 pub fn set_dlq_messages_count(queue: &str, status: &str, count: f64) {
     DLQ_MESSAGES.with_label_values(&[queue, status]).set(count);
 }
+
+lazy_static! {
+    pub static ref HEALTH_CHECK_STATUS: GaugeVec = register_gauge_vec!(
+        "utility_downstream_health_check_status",
+        "Health check status of downstream services (1 = UP, 0 = DOWN)",
+        &["service"]
+    )
+    .unwrap();
+}
+
+pub fn set_health_status(service: &str, status: f64) {
+    HEALTH_CHECK_STATUS
+        .with_label_values(&[service])
+        .set(status);
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,6 +10,7 @@ use tokio::sync::Mutex;
 
 pub mod alloc_tracker;
 pub mod handlers;
+pub mod health;
 pub mod metrics;
 pub mod middleware;
 pub mod rate_limit_config;
@@ -26,6 +27,7 @@ pub struct AppState {
     pub tenant_rate_limiter: Arc<TenantRateLimiter>,
     pub service_rate_limiter: Arc<ServiceRateLimiter>,
     pub hlc: Arc<HybridLogicalClock>,
+    pub health_aggregator: Arc<crate::api::health::HealthAggregator>,
 }
 
 impl FromRef<AppState> for Arc<NonceSequencer> {

--- a/src/api/router.rs
+++ b/src/api/router.rs
@@ -13,6 +13,8 @@ pub async fn build_router(state: AppState) -> anyhow::Result<Router> {
 
     let app = Router::new()
         .route("/health", get(|| async { "ok" }))
+        .route("/health/summary", get(crate::api::health::summary_health))
+        .route("/health/detailed", get(crate::api::health::detailed_health))
         .route("/readyz", get(handlers::readyz_handler))
         .route("/api/v1/meters", get(handlers::list_meters))
         .route("/api/v1/meters/:id", get(handlers::get_meter))

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,17 @@ async fn main() -> anyhow::Result<()> {
 
     utility_backend::incident::init_global_incident_manager(incident_manager.clone());
 
+    let mesh_discovery = Arc::new(utility_backend::service_mesh::client::ServiceMeshDiscovery::new());
+    let health_aggregator = Arc::new(utility_backend::api::health::HealthAggregator::new(
+        mesh_discovery.clone(),
+        utility_backend::service_mesh::ServiceMeshMtlsConfig::default(),
+        utility_backend::service_mesh::MeshIdentity {
+            trust_domain: "utility.local".to_string(),
+            namespace: "default".to_string(),
+            service_account: "utility-backend".to_string(),
+        },
+    ));
+
     let state = AppState {
         sequencer,
         pool: db_pool,
@@ -154,6 +165,7 @@ async fn main() -> anyhow::Result<()> {
         tenant_rate_limiter,
         service_rate_limiter,
         hlc,
+        health_aggregator,
     };
 
     let app = utility_backend::api::router::build_router(state).await?;


### PR DESCRIPTION


### Pull Request

**Title**: Feat: Add unified downstream service health check aggregation endpoint

**Description**:

**Summary**
This PR implements a unified endpoint that aggregates health checks from all registered microservices, providing a single source of truth for system status for the Operations team. 

**Issue**
Closes #244 
---

**Root Cause**
The backend previously only monitored its own internal components (e.g. database connection pool) without a system-wide view of external dependencies dynamically registered in the service mesh.

**Solution Implemented**
Introduces a new `HealthAggregator` service injected into the `AppState`. It dynamically queries `ServiceMeshDiscovery` endpoints, executes parallel HTTP health checks using `ServiceMeshClient`, updates Prometheus metrics, caches results for 10 seconds, and relies on per-service circuit breakers to prevent overwhelming failing services.
---
**Key Changes**
- Added `/health/summary` and `/health/detailed` API endpoints.
- Implemented a 10-second TTL caching layer for health checks.
- Implemented parallel downstream polling with `futures::future::join_all`.
- Integrated a lightweight health check circuit breaker per downstream endpoint.
- Introduced `utility_downstream_health_check_status` Prometheus gauge.
---
**Affected Files**
- `src/api/health.rs` — [NEW] Caching, circuit breaking, aggregation logic, and axum handlers.
- `src/api/metrics.rs` — Added Prometheus metric `HEALTH_CHECK_STATUS`.
- `src/api/mod.rs` — Added `HealthAggregator` to global `AppState`.
- `src/api/router.rs` — Registered new health routing paths.
- `src/main.rs` — Initialised `ServiceMeshDiscovery` and `HealthAggregator` on backend startup.
---
**Trade-offs / Considerations**
- Designed a separate lightweight `HealthCircuitBreaker` in `health.rs` rather than adapting the highly specialized `soroban::rpc::CircuitBreaker`, preventing overly broad dependencies across disparate networking concepts.
- The base `/health` endpoint remains unmodified (returns simple "ok") to prevent existing load balancer disruption.

**Testing**
- Added isolated unit tests for circuit breaker logic (Closed -> Open -> Half-Open).
- *Note:* Full compilation tests are currently blocked locally due to `cmake` being unavailable on the build environment, affecting `prost` bindings.
---

PLEASE VERIFY MY WORK!